### PR TITLE
(#47) fix laser rendering

### DIFF
--- a/Source/Bloodmasters.Tests/Graphics/Vector3DTests.cs
+++ b/Source/Bloodmasters.Tests/Graphics/Vector3DTests.cs
@@ -1,0 +1,36 @@
+using CodeImp.Bloodmasters;
+
+namespace Bloodmasters.Tests.Graphics;
+
+public class Vector3DTests
+{
+    [Fact(DisplayName = "Vector3D copy constructor should correctly copy data from source Vector3D")]
+    public void CopyConstructorShouldCorrectlyCopyDataFromSourceVector3D()
+    {
+        // Arrange
+        var source = new Vector3D(1f, 2f, 3f);
+
+        // Act
+        var result = new Vector3D(source);
+
+        // Assert
+        Assert.Equal(source.x, result.x);
+        Assert.Equal(source.y, result.y);
+        Assert.Equal(source.z, result.z);
+    }
+
+    [Fact(DisplayName = "Vector3D copy constructor should correctly copy data from source Vector2D")]
+    public void CopyConstructorShouldCorrectlyCopyDataFromSourceVector2D()
+    {
+        // Arrange
+        var source = new Vector3D(1f, 2f, 3f);
+
+        // Act
+        var result = new Vector3D((Vector2D)source);
+
+        // Assert
+        Assert.Equal(source.x, result.x);
+        Assert.Equal(source.y, result.y);
+        Assert.Equal(0, result.z);
+    }
+}

--- a/Source/Client/Effects/Shock.cs
+++ b/Source/Client/Effects/Shock.cs
@@ -90,8 +90,8 @@ namespace CodeImp.Bloodmasters.Client
 			segments = corners + 1;
 
 			// Project the trajectory coordinates
-			from2d = new Vector3D(General.arena.Projected(from.ToDx()).FromDx());
-			to2d = new Vector3D(General.arena.Projected(to.ToDx()).FromDx());
+			from2d = General.arena.Projected(from.ToDx()).FromDx();
+			to2d = General.arena.Projected(to.ToDx()).FromDx();
 			delta2d = to2d - from2d;
 
 			// Calculate segment length scalar in 2D
@@ -134,8 +134,8 @@ namespace CodeImp.Bloodmasters.Client
 					p4 = (ve + (trjnorm * soffset)) - (trjnorm * swidth);
 
 					// Unproject vertices to 3D space
-					v3 = new Vector3D(General.arena.Unprojected(p3.ToDx()).FromDx());
-					v4 = new Vector3D(General.arena.Unprojected(p4.ToDx()).FromDx());
+					v3 = General.arena.Unprojected(p3.ToDx()).FromDx();
+					v4 = General.arena.Unprojected(p4.ToDx()).FromDx();
 				}
 
 				// Make real vertices

--- a/Source/Client/Graphics/Laser.cs
+++ b/Source/Client/Graphics/Laser.cs
@@ -66,8 +66,8 @@ namespace CodeImp.Bloodmasters.Client
 			float width = WIDTH * ((float)Direct3D.DisplayWidth / 640f);
 
 			// Project the coordinates
-			from2d = new Vector3D(General.arena.Projected(from.ToDx()).FromDx());
-			to2d = new Vector3D(General.arena.Projected(to.ToDx()).FromDx());
+            from2d = General.arena.Projected(from.ToDx()).FromDx();
+			to2d = General.arena.Projected(to.ToDx()).FromDx();
 			delta2d = to2d - from2d;
 
 			// Determine trajectory normal
@@ -81,10 +81,10 @@ namespace CodeImp.Bloodmasters.Client
 			p4 = to2d + trjnorm * width;
 
 			// Unproject to 3D space
-			n[0] = new Vector3D(General.arena.Unprojected(p1.ToDx()).FromDx());
-			n[1] = new Vector3D(General.arena.Unprojected(p2.ToDx()).FromDx());
-			n[2] = new Vector3D(General.arena.Unprojected(p3.ToDx()).FromDx());
-			n[3] = new Vector3D(General.arena.Unprojected(p4.ToDx()).FromDx());
+			n[0] = General.arena.Unprojected(p1.ToDx()).FromDx();
+			n[1] = General.arena.Unprojected(p2.ToDx()).FromDx();
+			n[2] = General.arena.Unprojected(p3.ToDx()).FromDx();
+			n[3] = General.arena.Unprojected(p4.ToDx()).FromDx();
 
 			// Set vertex properties
 			for(int i = 0; i < 4; i++)

--- a/Source/Shared/Vector3D.cs
+++ b/Source/Shared/Vector3D.cs
@@ -22,6 +22,14 @@ namespace CodeImp.Bloodmasters
 			this.z = z;
 		}
 
+        // Constructor
+        public Vector3D(Vector3D v)
+        {
+            this.x = v.x;
+            this.y = v.y;
+            this.z = v.z;
+        }
+
 		// Constructor
 		public Vector3D(Vector2D v)
 		{


### PR DESCRIPTION
Vector3D copy constructor had no overload for copying from Vector3D, instead, it used copy constructor from Vector2D (and it used it as there is an implicit cast of Vector3D to Vector2D), so `z` component was completely ignored

After fix:

[fix.webm](https://github.com/ForNeVeR/bloodmasters/assets/38229504/1f65d9cf-b8ba-40ca-b551-56641f00eae7)

Fix #47 