### PR TITLE
Pass refresh rate to PresentParameters on fullscreen

### DIFF
--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -1287,6 +1287,7 @@ namespace CodeImp.Bloodmasters.Client
 			d3dpp.BackBufferHeight = mode.Height;
 			d3dpp.EnableAutoDepthStencil = true;
 			d3dpp.AutoDepthStencilFormat = Format.D16;
+            d3dpp.FullScreenRefreshRateInHz = windowed ? 0 : mode.RefreshRate;
 
 			// Check if using fullscreen antialiasing
 			if(fsaa > -1)


### PR DESCRIPTION
Not sure if it does anything, but IMO it's better to pass it explicitly.

According to the [documentation](https://learn.microsoft.com/en-us/previous-versions/ms885061(v=msdn.10)), windowed mode should have this value set to 0, and non-windowed should get it from `DisplayMode`