### PR TITLE
(#12) pass single vertex size to SetStreamSource instead of entire buffer size

### DIFF
--- a/Source/Client/General/Arena.cs
+++ b/Source/Client/General/Arena.cs
@@ -1478,7 +1478,7 @@ namespace CodeImp.Bloodmasters.Client
 			// Shadow texture and vertices
 			Direct3D.d3dd.SetTexture(0, Shadow.texture.texture);
 			Direct3D.d3dd.SetTexture(1, null);
-			Direct3D.d3dd.SetStreamSource(0, Shadow.vertices, 0, Shadow.vertices.Description.SizeInBytes); // TODO[#12]: SizeInBytes is suspicious, was TypeSize originally, check/compare this
+			Direct3D.d3dd.SetStreamSource(0, Shadow.vertices, 0, MVertex.Stride);
 
 			// Go for all visual objects
 			foreach(VisualObject vo in objects)

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -2002,11 +2002,11 @@ namespace CodeImp.Bloodmasters.Client
 	}
 
 	// MVertex
-	public struct MVertex
+    public struct MVertex
 	{
 		// Vertex format
 		public static readonly VertexFormat Format = VertexFormat.Position | VertexFormat.Texture3 | VertexFormat.Diffuse;
-		public const int Stride = 10 * 4;
+		public static readonly unsafe int Stride = sizeof(MVertex);
 
 		// Members
 		public float x;
@@ -2026,7 +2026,7 @@ namespace CodeImp.Bloodmasters.Client
 	{
 		// Vertex format
 		public static readonly VertexFormat Format = VertexFormat.Position | VertexFormat.Diffuse;
-		public static readonly int Stride = 4 * 4;
+		public static readonly unsafe int Stride = sizeof(LVertex);
 
 		// Members
 		public float x;
@@ -2040,7 +2040,7 @@ namespace CodeImp.Bloodmasters.Client
 	{
 		// Vertex format
 		public static readonly VertexFormat Format = VertexFormat.PositionRhw | VertexFormat.Texture1 | VertexFormat.Diffuse;
-		public static readonly int Stride = 7 * 4;
+		public static readonly unsafe int Stride = sizeof(TLVertex);
 
 		// Members
 		public float x;
@@ -2057,7 +2057,7 @@ namespace CodeImp.Bloodmasters.Client
 	{
 		// Vertex format
 		public static readonly VertexFormat Format = VertexFormat.Position | VertexFormat.PointSize | VertexFormat.Diffuse;
-		public static readonly int Stride = 5 * 4;
+		public static readonly unsafe int Stride = sizeof(PVertex);
 
 		// Members
 		public float x;

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -2006,7 +2006,7 @@ namespace CodeImp.Bloodmasters.Client
 	{
 		// Vertex format
 		public static readonly VertexFormat Format = VertexFormat.Position | VertexFormat.Texture3 | VertexFormat.Diffuse;
-		public static readonly int Stride = 10 * 4;
+		public const int Stride = 10 * 4;
 
 		// Members
 		public float x;


### PR DESCRIPTION
So it was indeed an incorrect value.
[Documentation](https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3dvertexbuffer-desc#members) for `VertexBufferDescription` says that `Size` property refers to the entire buffer size, while `SetStreamSource` expects size of single vertex.

I've checked and it previously passed 160 (4 vertexes * 40), and after fix it correctly passes 40.

Closes #12