### PR TITLE
Use generic collections

### DIFF
--- a/Source/Client/Effects/FireFlame.cs
+++ b/Source/Client/Effects/FireFlame.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp.Bloodmasters;
 using CodeImp;
 using SharpDX.Direct3D9;

--- a/Source/Client/Effects/ILightningNode.cs
+++ b/Source/Client/Effects/ILightningNode.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp.Bloodmasters;
 using CodeImp;
 
@@ -18,7 +17,7 @@ namespace CodeImp.Bloodmasters.Client
 		// Required properties
 		Vector3D Position { get; }
 		Vector3D Velocity { get; }
-		
+
 		// Required methods
 		void RemoveLightning(Lightning l);
 		void AddLightning(Lightning l);

--- a/Source/Client/Effects/IonExplodeEffect.cs
+++ b/Source/Client/Effects/IonExplodeEffect.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using SharpDX.Direct3D9;
 
 namespace CodeImp.Bloodmasters.Client
@@ -26,7 +26,7 @@ namespace CodeImp.Bloodmasters.Client
 		private ClientSector sector;
 		private bool disposed;
 		private int shockendtime;
-		private ArrayList lightnings = new ArrayList();
+		private List<Lightning> lightnings = new();
 		private int source;
 		private TEAM team;
 
@@ -181,7 +181,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// Dispose them all
 				for(int i = lightnings.Count - 1; i >= 0; i--)
-					((Lightning)lightnings[i]).Dispose();
+					lightnings[i].Dispose();
 			}
 		}
 

--- a/Source/Client/Effects/RageEffect.cs
+++ b/Source/Client/Effects/RageEffect.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp.Bloodmasters;
 using CodeImp;
 using SharpDX.Direct3D9;

--- a/Source/Client/Effects/Shock.cs
+++ b/Source/Client/Effects/Shock.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -43,7 +43,7 @@ namespace CodeImp.Bloodmasters.Client
 		// Constructor
 		public Shock(Vector3D from, Vector3D to, float fadechange)
 		{
-			ArrayList v = new ArrayList();
+			List<MVertex> v = new List<MVertex>();
 
 			// Set fade speed
 			this.fadechange = fadechange;
@@ -60,13 +60,13 @@ namespace CodeImp.Bloodmasters.Client
 			// Make the shock
 			AddShockVertices(v, from, to);
 
-			// Make vertices array from arraylist
-			verts = (MVertex[])v.ToArray(typeof(MVertex));
+			// Make vertices array from list
+			verts = v.ToArray();
 			faces = verts.Length / 3;
 		}
 
 		// This adds shock vertices over a trajectory
-		private void AddShockVertices(ArrayList v, Vector3D from, Vector3D to)
+		private void AddShockVertices(List<MVertex> v, Vector3D from, Vector3D to)
 		{
 			int corners, segments;
 			float rnd_offset, rnd_width, min_width;

--- a/Source/Client/General/Actor.cs
+++ b/Source/Client/General/Actor.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -125,7 +125,7 @@ namespace CodeImp.Bloodmasters.Client
 
 		// Effects
 		private FireEffect fireeffect = null;
-		private ArrayList lightnings = new ArrayList();
+		private List<Lightning> lightnings = new();
 		private RageEffect rageeffect = null;
 		private int ragecolor = -1;
 
@@ -157,7 +157,7 @@ namespace CodeImp.Bloodmasters.Client
 		public bool ShowNuke { get { return shownuke; } set { shownuke = value; } }
 		public bool ShowRing { get { return showring; } set { showring = value; } }
 		public Vector3D Velocity { get { return state.vel; } }
-		public ArrayList Lightnings { get { return lightnings; } }
+		public List<Lightning> Lightnings { get { return lightnings; } }
 		public TEAM Team { get { return team; } }
 		public int ClientID { get { return clientid; } }
 		public bool ShowRage { get { return showrage; } set { showrage = value; } }
@@ -290,7 +290,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// Dispose them all
 				for(int i = lightnings.Count - 1; i >= 0; i--)
-					((Lightning)lightnings[i]).Dispose();
+					lightnings[i].Dispose();
 			}
 		}
 
@@ -547,18 +547,18 @@ namespace CodeImp.Bloodmasters.Client
 		public void FindHighestSector()
 		{
 			// Find touching sectors
-			ArrayList sectors = General.map.FindTouchingSectors(state.pos.x, state.pos.y, Consts.PLAYER_RADIUS);
+            List<Sector> sectors = General.map.FindTouchingSectors(state.pos.x, state.pos.y, Consts.PLAYER_RADIUS);
 
 			// Start with the current
 			highestsector = sector;
 			float highestz = sector.CurrentFloor;
 
 			// Find the highest sector floor
-			foreach(ClientSector s in sectors)
+            foreach(ClientSector s in sectors)
 			{
 				// Check if higher but not blocking
-				if((s.CurrentFloor > highestz) &&
-				   (s.CurrentFloor - Consts.MAX_STEP_HEIGHT <= state.pos.z))
+                if((s.CurrentFloor > highestz) &&
+                   (s.CurrentFloor - Consts.MAX_STEP_HEIGHT <= state.pos.z))
 				{
 					// This height is higher and still valid
 					highestz = s.CurrentFloor;

--- a/Source/Client/General/Client.cs
+++ b/Source/Client/General/Client.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 
@@ -51,7 +51,7 @@ namespace CodeImp.Bloodmasters.Client
 		private Item carry = null;
 
 		// Local client only
-		private ArrayList localmoves;
+		private List<LocalMove> localmoves;
 
 		// Player status (local only)
 		private int health;
@@ -140,7 +140,7 @@ namespace CodeImp.Bloodmasters.Client
 			if(local)
 			{
 				// Set up variables for local client
-				localmoves = new ArrayList();
+				localmoves = new List<LocalMove>();
 			}
 		}
 
@@ -421,7 +421,7 @@ namespace CodeImp.Bloodmasters.Client
 					for(int i = actor.Lightnings.Count - 1; i >= 0; i--)
 					{
 						// Get the lightning object
-						Lightning l = (Lightning)actor.Lightnings[i];
+						Lightning l = actor.Lightnings[i];
 
 						// Remove lightning if coming from me
 						if(l.Source == this.Actor) l.Dispose();
@@ -896,7 +896,7 @@ namespace CodeImp.Bloodmasters.Client
 				while(i < localmoves.Count)
 				{
 					// Get the move object
-					lm = (LocalMove)localmoves[i];
+					lm = localmoves[i];
 
 					// Correct the move
 					if(lm.CorrectMove(basetime))

--- a/Source/Client/General/ClientComparer.cs
+++ b/Source/Client/General/ClientComparer.cs
@@ -6,43 +6,35 @@
 \********************************************************************/
 
 using System;
-using System.Drawing;
-using System.Globalization;
-using System.Collections;
-using CodeImp.Bloodmasters;
-using CodeImp;
+using System.Collections.Generic;
 
 namespace CodeImp.Bloodmasters.Client
 {
-	public class ClientComparer : IComparer
+	public class ClientComparer : IComparer<Client>
 	{
 		// Comparer method
-		public int Compare(object x, object y)
+		public int Compare(Client a, Client b)
 		{
 			int teama, teamb;
 			int scorea, scoreb;
 			int fragsa, fragsb;
-			
-			// Get client objects
-			Client a = (Client)x;
-			Client b = (Client)y;
-			
-			// Make team/spectator index
+
+            // Make team/spectator index
 			teama = Scoreboard.GetSectionIndex(a);
 			teamb = Scoreboard.GetSectionIndex(b);
-			
+
 			// Make reversed values
 			scorea = 9999 - a.Score;
 			scoreb = 9999 - b.Score;
 			fragsa = 9999 - a.Frags;
 			fragsb = 9999 - b.Frags;
-			
+
 			// Make comparable strings
-			string sa = teama.ToString() + "_" + scorea.ToString("0000000") + "_" + fragsa.ToString("0000") + "_" + a.Deaths.ToString("0000") + "_" + a.Name + "_" + a.ID.ToString("00");
-			string sb = teamb.ToString() + "_" + scoreb.ToString("0000000") + "_" + fragsb.ToString("0000") + "_" + b.Deaths.ToString("0000") + "_" + b.Name + "_" + b.ID.ToString("00");
-			
+			string sa = teama + "_" + scorea.ToString("0000000") + "_" + fragsa.ToString("0000") + "_" + a.Deaths.ToString("0000") + "_" + a.Name + "_" + a.ID.ToString("00");
+			string sb = teamb + "_" + scoreb.ToString("0000000") + "_" + fragsb.ToString("0000") + "_" + b.Deaths.ToString("0000") + "_" + b.Name + "_" + b.ID.ToString("00");
+
 			// Compare and return result
-			return string.Compare(sa, sb);
+			return string.Compare(sa, sb, StringComparison.InvariantCulture);
 		}
-	}
+    }
 }

--- a/Source/Client/General/GameMenu.cs
+++ b/Source/Client/General/GameMenu.cs
@@ -9,7 +9,6 @@ using System;
 using System.Text;
 using System.Drawing;
 using System.Globalization;
-using System.Collections;
 using System.Collections.Specialized;
 using System.Reflection;
 using System.Windows.Forms;

--- a/Source/Client/General/LocalMove.cs
+++ b/Source/Client/General/LocalMove.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Drawing;
 using System.Globalization;
-using System.Collections;
 using CodeImp.Bloodmasters;
 using CodeImp;
 
@@ -19,7 +18,7 @@ namespace CodeImp.Bloodmasters.Client
 		// Variables
 		private int movetime;
 		private float walkangle;
-		
+
 		// Constructor
 		public LocalMove(int movetime, float walkangle)
 		{
@@ -27,19 +26,19 @@ namespace CodeImp.Bloodmasters.Client
 			this.movetime = movetime;
 			this.walkangle = walkangle;
 		}
-		
+
 		// This checks if the move is outdated
 		public bool CorrectMove(int basetime)
 		{
 			return (basetime < movetime);
 		}
-		
+
 		// This applies the move to an actor
 		public void ApplyTo(Actor actor)
 		{
 			float walkpower, walklimit;
 			Vector2D vel2d;
-			
+
 			// Moving at all?
 			if(walkangle > -1f)
 			{
@@ -49,21 +48,21 @@ namespace CodeImp.Bloodmasters.Client
 					// Determine walking power
 					if(!actor.IsOnFloor) walkpower = Consts.AIRWALK_LENGTH;
 					else walkpower = Consts.WALK_LENGTH;
-					
+
 					// Determine walking limit
 					if(General.localclient.Powerup != POWERUP.SPEED) walklimit = Consts.MAX_WALK_LENGTH;
 					else walklimit = Consts.MAX_SPEED_WALK_LENGTH;
-					
+
 					// Add to walk velocity
 					actor.State.vel.x += (float)Math.Sin(walkangle) * walkpower;
 					actor.State.vel.y += (float)Math.Cos(walkangle) * walkpower;
-					
+
 					// Scale to match walking length
 					vel2d = actor.State.vel;
 					if(vel2d.Length() > walklimit)
 						vel2d.MakeLength(walklimit);
 					actor.State.vel.Apply2D(vel2d);
-					
+
 					// Apply push vector
 					actor.State.vel += (Vector3D)actor.PushVector;
 				}

--- a/Source/Client/General/Scoreboard.cs
+++ b/Source/Client/General/Scoreboard.cs
@@ -9,7 +9,7 @@
 // Name Score Frags Deaths Ping / Loss
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using SharpDX.Direct3D9;
 
@@ -55,7 +55,7 @@ namespace CodeImp.Bloodmasters.Client
 		private bool updateneeded = true;
 
 		// Clients array
-		private ArrayList clients;
+		private List<Client> clients;
 
 		// Window border and lines
 		private WindowBorder window;
@@ -91,7 +91,7 @@ namespace CodeImp.Bloodmasters.Client
 			string tempfile;
 
 			// Clients array
-			clients = new ArrayList(32);
+			clients = new List<Client>(32);
 
 			// Create window
 			window = new WindowBorder(TABLE_X - TABLE_BORDERSPACING,

--- a/Source/Client/Graphics/Animation.cs
+++ b/Source/Client/Graphics/Animation.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace CodeImp.Bloodmasters.Client
@@ -16,7 +16,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Variables
 
 		// Static variables
-		private static Hashtable animations = new Hashtable();
+		private static Dictionary<string, Animation> animations = new();
 
 		// Instance stuff
 		private int frametime;
@@ -148,14 +148,14 @@ namespace CodeImp.Bloodmasters.Client
 		public static bool IsLoaded(string anifile)
 		{
 			// Check if the specified animation is not loaded yet
-			return Animation.animations.Contains(anifile.ToLower());
+			return Animation.animations.ContainsKey(anifile.ToLower());
 		}
 
 		// This returns a new instance of an animation
 		public static Animation CreateFrom(string anifile)
 		{
 			// Get the loaded animation
-			Animation ani = (Animation)Animation.animations[anifile.ToLower()];
+			Animation ani = Animation.animations[anifile.ToLower()];
 
 			// Make a new animation with same properties
 			Animation newani = new Animation();
@@ -176,7 +176,7 @@ namespace CodeImp.Bloodmasters.Client
 		{
 			// Clear animations
 			Animation.animations.Clear();
-			Animation.animations = new Hashtable();
+			Animation.animations = new Dictionary<string, Animation>();
 		}
 
 		#endregion

--- a/Source/Client/Graphics/FloorDecal.cs
+++ b/Source/Client/Graphics/FloorDecal.cs
@@ -329,7 +329,7 @@ namespace CodeImp.Bloodmasters.Client
 			if((sector.InScreen) && (texture != null))
 			{
 				// Get the sector
-				Sector sc = (Sector)sector.Sectors[0];
+				Sector sc = sector.Sectors[0];
 
 				// Sector dynamic?
 				if(sc.Dynamic)

--- a/Source/Client/Graphics/ParticleCollection.cs
+++ b/Source/Client/Graphics/ParticleCollection.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -25,7 +25,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Variables
 
 		// The particles flock
-		private ArrayList particles = new ArrayList(INITIAL_PARTICLES_MEMORY);
+		private List<Particle> particles = new(INITIAL_PARTICLES_MEMORY);
 
 		// The texture
 		private TextureResource texture;
@@ -130,7 +130,7 @@ namespace CodeImp.Bloodmasters.Client
 			while(i < particles.Count)
 			{
 				// Process particle
-				p = (Particle)particles[i];
+				p = particles[i];
 				p.Process();
 
 				// Trash when disposed or move on to the next

--- a/Source/Client/Graphics/SectorShadow.cs
+++ b/Source/Client/Graphics/SectorShadow.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using SharpDX.Direct3D9;
 
 namespace CodeImp.Bloodmasters.Client
@@ -48,7 +48,7 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This makes a sector shadow from a line
-		public bool MakeSectorShadow(ArrayList vertices, VisualSector vs, Linedef l)
+		public bool MakeSectorShadow(List<TLVertex> vertices, VisualSector vs, Linedef l)
 		{
 			TLVertex v;
 			float fall_x, fall_y;

--- a/Source/Client/Graphics/VisualSector.cs
+++ b/Source/Client/Graphics/VisualSector.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
@@ -34,7 +34,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Variables
 
 		// Reference to sector data
-		private ArrayList sectors;
+		private List<ClientSector> sectors;
 		private int index;
 
 		// This is set to true when sector is in screen
@@ -51,14 +51,14 @@ namespace CodeImp.Bloodmasters.Client
 		private VertexBuffer shadowvertices = null;
 
 		// SectorShadows on this sector
-		private ArrayList sectorshadows;
+		private List<SectorShadow> sectorshadows;
 
 		// Sidedefs in this sector
-		private ArrayList sidedefs;
+		private List<VisualSidedef> sidedefs;
 
 		// Floor and ceiling textures
-		private ArrayList tfloors;
-		private ArrayList tceils;
+		private List<ITextureResource> tfloors;
+		private List<ITextureResource> tceils;
 
 		// Heights
 		private float lowestfloor;
@@ -83,7 +83,7 @@ namespace CodeImp.Bloodmasters.Client
 		private int debugcolor = 0;
 
 		// Lists of nearby lights
-		private ArrayList lights = new ArrayList();
+        private List<StaticLight> lights = new();
 
 		#endregion
 
@@ -100,13 +100,13 @@ namespace CodeImp.Bloodmasters.Client
 		public Texture Lightmap { get { return lightmap; } }
 		public bool InScreen { get { return inscreen; } }
 		public bool DynamicLightmap { get { return dynamiclightmap; } }
-		public ArrayList Sectors { get { return sectors; } }
-		public ArrayList VisualSidedefs { get { return sidedefs; } }
+		public List<ClientSector> Sectors { get { return sectors; } }
+		public List<VisualSidedef> VisualSidedefs { get { return sidedefs; } }
 		public int LightmapSize { get { return lightmapsize; } }
 		public float LightmapUnit { get { return lightmapunit; } }
 		public float LowestFloor { get { return lowestfloor; } }
 		public float HighestFloor { get { return highestfloor; } }
-		public ArrayList Lights { get { return lights; } }
+		public List<StaticLight> Lights { get { return lights; } }
 		public int AmbientLight { get { return ambientlight; } }
 		public bool FixedLight { get { return fixedlight; } }
 		public int Index { get { return index; } }
@@ -119,10 +119,10 @@ namespace CodeImp.Bloodmasters.Client
 		public VisualSector(ClientSector sector)
 		{
 			// Make arrays
-			sectors = new ArrayList();
-			tfloors = new ArrayList();
-			tceils = new ArrayList();
-			sectorshadows = new ArrayList();
+			sectors = new List<ClientSector>();
+			tfloors = new List<ITextureResource>();
+			tceils = new List<ITextureResource>();
+			sectorshadows = new List<SectorShadow>();
 
 			// Make references
 			sectors.Add(sector);
@@ -181,7 +181,7 @@ namespace CodeImp.Bloodmasters.Client
 			}
 
 			// Make list of sidedefs
-			sidedefs = new ArrayList();
+			sidedefs = new List<VisualSidedef>();
 			foreach(SubSector ss in sector.Subsectors)
 			{
 				// Go for all segments
@@ -241,7 +241,7 @@ namespace CodeImp.Bloodmasters.Client
 		public void WriteSectorDebugInfo(StreamWriter writer)
 		{
 			// Go for all sectors
-			foreach(Sector ss in sectors)
+			foreach(ClientSector ss in sectors)
 			{
 				// Output information
 				writer.WriteLine("   Sector " + ss.Index);
@@ -351,7 +351,7 @@ namespace CodeImp.Bloodmasters.Client
 		public bool CanBeVisible(int fromsector)
 		{
 			// Go for all sectors
-			foreach(Sector s in sectors)
+			foreach(ClientSector s in sectors)
 			{
 				// Return true when any portion is visible
 				if(General.map.RejectMap.CanBeVisible(fromsector, s.Index))
@@ -623,21 +623,21 @@ namespace CodeImp.Bloodmasters.Client
 			ClientSector sc;
 			int i;
 			float lmtop = 0f;
-			ArrayList newverts;
+            List<MVertex> newverts;
 
 			// Make shadows geometry
 			MakeSectorShadows();
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+            List<MVertex> verts = new List<MVertex>();
 
 			// Go for all sectors
 			for(i = 0; i < sectors.Count; i++)
 			{
 				// Get the sector and textures
-				sc = (ClientSector)sectors[i];
-				tc = (ITextureResource)tceils[i];
-				tf = (ITextureResource)tfloors[i];
+				sc = sectors[i];
+				tc = tceils[i];
+				tf = tfloors[i];
 
 				// Floor?
 				if(tf != null)
@@ -724,12 +724,12 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This builds floor vertices for subsectors
-		private ArrayList MakeSubSectorPolygon(SubSector s, bool floor, ITextureResource tex)
+		private List<MVertex> MakeSubSectorPolygon(SubSector s, bool floor, ITextureResource tex)
 		{
 			MVertex v1, v2, v3;
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+            List<MVertex> verts = new List<MVertex>();
 
 			// First vertex is always begin of first segment
 			v1 = MakeSectorVertex(s.Segments[0].v1, s, floor, tex);
@@ -803,13 +803,13 @@ namespace CodeImp.Bloodmasters.Client
 			SectorShadow ss;
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+            List<TLVertex> verts = new List<TLVertex>();
 
 			// Determine in which area linedefs should be used
 			RectangleF shadowarea = RectangleEx.Inflate(secbounds, 10f, 10f);
 
 			// Go for all nearby linedefs
-			ArrayList lines = General.map.BlockMap.GetCollisionLines(shadowarea.ToSystemDrawing());
+            List<Linedef> lines = General.map.BlockMap.GetCollisionLines(shadowarea.ToSystemDrawing());
 			foreach(Linedef l in lines)
 			{
 				// Make sector shadow
@@ -893,7 +893,7 @@ namespace CodeImp.Bloodmasters.Client
 			for(int i = 0; i < sectors.Count; i++)
 			{
 				// Get the sector
-				sc = (ClientSector)sectors[i];
+				sc = sectors[i];
 
 				// Does it have a floor?
 				if(tfloors[i] != null)
@@ -932,8 +932,8 @@ namespace CodeImp.Bloodmasters.Client
 				for(i = 0; i < sectors.Count; i++)
 				{
 					// Get the sector and texture
-					sc = (ClientSector)sectors[i];
-					t = (ITextureResource)tceils[i];
+					sc = sectors[i];
+					t = tceils[i];
 
 					// Ceiling?
 					if(t != null)
@@ -954,8 +954,8 @@ namespace CodeImp.Bloodmasters.Client
 				for(i = 0; i < sectors.Count; i++)
 				{
 					// Get the sector and texture
-					sc = (ClientSector)sectors[i];
-					t = (ITextureResource)tfloors[i];
+					sc = sectors[i];
+					t = tfloors[i];
 
 					// Floor?
 					if(t != null)

--- a/Source/Client/Graphics/VisualSidedef.cs
+++ b/Source/Client/Graphics/VisualSidedef.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX.Direct3D9;
 
@@ -166,7 +166,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Geometry
 
 		// This adds a quad of vertices to an array
-		private void AddVertexQuad(ArrayList list, int v1, int v2, float top, float bot,
+		private void AddVertexQuad(List<MVertex> list, int v1, int v2, float top, float bot,
 									float tl, float tt, float tr, float tb,
 									int begincolor, int endcolor)
 		{
@@ -245,7 +245,7 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This builds middle wall vertices
-		public ArrayList MakeMiddleWall(int vertexoffset)
+		public List<MVertex> MakeMiddleWall(int vertexoffset)
 		{
 			float ttop, tbottom, tleft, tright;
 			int endcolor = -1;
@@ -253,7 +253,7 @@ namespace CodeImp.Bloodmasters.Client
 			float tdelta;
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+            List<MVertex> verts = new List<MVertex>();
 
 			// Check if a middle wall exists
 			if(tmiddle != null)
@@ -323,14 +323,14 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This builds lower wall vertices
-		public ArrayList MakeLowerWall(int vertexoffset)
+		public List<MVertex> MakeLowerWall(int vertexoffset)
 		{
 			float ttop, tbottom, tleft, tright;
 			int endcolor = -1;
 			int begincolor = -1;
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+            List<MVertex> verts = new List<MVertex>();
 
 			// Check if a lower wall is possible
 			if((tlower != null) && (sidedef.OtherSide != null))
@@ -374,13 +374,13 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This builds upper wall vertices
-		public ArrayList MakeUpperWall(int vertexoffset)
+		public List<MVertex> MakeUpperWall(int vertexoffset)
 		{
 			float ttop, tbottom, tleft, tright;
 			float topdiff;
 
 			// This will temporarely hold the vertices
-			ArrayList verts = new ArrayList();
+			List<MVertex> verts = new List<MVertex>();
 
 			// Check if a upper wall is possible
 			if((tupper != null) && (sidedef.OtherSide != null))

--- a/Source/Client/Graphics/WallDecal.cs
+++ b/Source/Client/Graphics/WallDecal.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -138,7 +138,7 @@ namespace CodeImp.Bloodmasters.Client
 			if(!Decal.showdecals) return null;
 
 			// Get all lines near rectangle
-			ArrayList lines = General.map.BlockMap.GetCollisionLines(nx, ny, size);
+            List<Linedef> lines = General.map.BlockMap.GetCollisionLines(nx, ny, size);
 			if(lines.Count > 0)
 			{
 				// Get the nearest line

--- a/Source/Client/Interface/FormServer.cs
+++ b/Source/Client/Interface/FormServer.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Text;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Diagnostics;
@@ -23,14 +22,14 @@ namespace CodeImp.Bloodmasters.Client
 		private System.Windows.Forms.Label lblInfo;
 		private System.Windows.Forms.RichTextBox rtbConsole;
 		private System.ComponentModel.Container components = null;
-		
+
 		// Constructor
 		public FormServer()
 		{
 			// Required for Windows Form Designer support
 			InitializeComponent();
 		}
-		
+
 		// Clean up any resources being used.
 		protected override void Dispose( bool disposing )
 		{
@@ -40,11 +39,11 @@ namespace CodeImp.Bloodmasters.Client
 				// Dispose components, if any
 				if(components != null) components.Dispose();
 			}
-			
+
 			// Let superior class know about the dispose
 			base.Dispose(disposing);
 		}
-		
+
 		#region Windows Form Designer generated code
 		/// <summary>
 		/// Required method for Designer support - do not modify
@@ -55,10 +54,10 @@ namespace CodeImp.Bloodmasters.Client
 			this.lblInfo = new System.Windows.Forms.Label();
 			this.rtbConsole = new System.Windows.Forms.RichTextBox();
 			this.SuspendLayout();
-			// 
+			//
 			// lblInfo
-			// 
-			this.lblInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.lblInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lblInfo.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
 			this.lblInfo.Location = new System.Drawing.Point(4, 4);
@@ -67,11 +66,11 @@ namespace CodeImp.Bloodmasters.Client
 			this.lblInfo.TabIndex = 0;
 			this.lblInfo.Text = "Bloodmasters dedicated server is running.  Close this window to stop the server.";
 			this.lblInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
+			//
 			// rtbConsole
-			// 
-			this.rtbConsole.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-				| System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.rtbConsole.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+				| System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.rtbConsole.BackColor = System.Drawing.Color.Black;
 			this.rtbConsole.DetectUrls = false;
@@ -85,9 +84,9 @@ namespace CodeImp.Bloodmasters.Client
 			this.rtbConsole.Size = new System.Drawing.Size(554, 234);
 			this.rtbConsole.TabIndex = 1;
 			this.rtbConsole.Text = "";
-			// 
+			//
 			// FormServer
-			// 
+			//
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.ClientSize = new System.Drawing.Size(558, 271);
 			this.Controls.Add(this.rtbConsole);
@@ -102,20 +101,20 @@ namespace CodeImp.Bloodmasters.Client
 
 		}
 		#endregion
-		
+
 		// Window closing
 		private void FormServer_Closing(object sender, System.ComponentModel.CancelEventArgs e)
 		{
 			// Stop the server
 			General.serverrunning = false;
 		}
-		
+
 		// This updates the console
 		public void WriteLine(string text)
 		{
 			Write(text + "\n");
 		}
-		
+
 		// This updates the console
 		public void Write(string text)
 		{
@@ -125,15 +124,15 @@ namespace CodeImp.Bloodmasters.Client
 				// Jump to the end
 				rtbConsole.SelectionStart = int.MaxValue;
 				rtbConsole.SelectionLength = 0;
-				
+
 				// Insert text
 				rtbConsole.AppendText(text);
-				
+
 				// Jump to the end again
 				rtbConsole.SelectionStart = int.MaxValue;
 				rtbConsole.SelectionLength = 0;
 				rtbConsole.ScrollToCaret();
-				
+
 				// Update window
 				this.Update();
 			}

--- a/Source/Client/Items/ScavengerItem.cs
+++ b/Source/Client/Items/ScavengerItem.cs
@@ -5,8 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-
 namespace CodeImp.Bloodmasters.Client
 {
 	public class ScavengerItem : Item
@@ -47,15 +45,12 @@ namespace CodeImp.Bloodmasters.Client
 			int result = 0;
 
 			// Go for all items in the map
-			foreach(DictionaryEntry de in General.arena.Items)
+			foreach(Item item in General.arena.Items.Values)
 			{
 				// Is this a scavenger item?
-				if(de.Value is ScavengerItem)
+				if(item is ScavengerItem si)
 				{
-					// Get the object
-					ScavengerItem si = (ScavengerItem)de.Value;
-
-					// Count item when for this team
+                    // Count item when for this team
 					if(si.thisteam == team) result++;
 				}
 			}
@@ -70,15 +65,12 @@ namespace CodeImp.Bloodmasters.Client
 			int result = 0;
 
 			// Go for all items in the map
-			foreach(DictionaryEntry de in General.arena.Items)
+            foreach(Item item in General.arena.Items.Values)
 			{
 				// Is this a scavenger item?
-				if(de.Value is ScavengerItem)
+				if(item is ScavengerItem si)
 				{
-					// Get the object
-					ScavengerItem si = (ScavengerItem)de.Value;
-
-					// Item for this team?
+                    // Item for this team?
 					if(si.thisteam == team)
 					{
 						// Count when item is not taken yet
@@ -95,19 +87,16 @@ namespace CodeImp.Bloodmasters.Client
 		public static void RespawnItems(TEAM team)
 		{
 			// Go for all items in the map
-			foreach(DictionaryEntry de in General.arena.Items)
+            foreach(Item item in General.arena.Items.Values)
 			{
 				// Is this a scavenger item?
-				if(de.Value is ScavengerItem)
+				if(item is ScavengerItem si)
 				{
-					// Get the object
-					ScavengerItem si = (ScavengerItem)de.Value;
-
-					// Item for this team?
+                    // Item for this team?
 					if(si.thisteam == team)
 					{
 						// Respawn the item now
-						si.Respawn(false);
+                        si.Respawn(false);
 					}
 				}
 			}

--- a/Source/Client/Lights/DynamicLight.cs
+++ b/Source/Client/Lights/DynamicLight.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -114,8 +114,8 @@ namespace CodeImp.Bloodmasters.Client
 				//Direct3D.d3dd.SetTexture(0, DynamicLight.lightimages[template].texture);
 
 				// Get all the nearby lines to check for intersection
-				ArrayList lines = General.map.BlockMap.GetCollisionLines(pos.x, pos.y, range);
-				ArrayList sectors = new ArrayList(lines.Count * 2);
+                List<Linedef> lines = General.map.BlockMap.GetCollisionLines(pos.x, pos.y, range);
+				List<Sector> sectors = new List<Sector>(lines.Count * 2);
 
 				// Go for all lines
 				foreach(Linedef ld in lines)
@@ -130,7 +130,7 @@ namespace CodeImp.Bloodmasters.Client
 				if(sectors.Count == 0) sectors.Add(General.map.GetSubSectorAt(pos.x, pos.y).Sector);
 
 				// Go for all sectors
-				foreach(ClientSector s in sectors)
+                foreach(ClientSector s in sectors)
 				{
 					// Visual Sector not done yet?
 					if((s.VisualSector != null) && s.VisualSector.InScreen && !donevsectors[s.VisualSector.Index])

--- a/Source/Client/Lights/StaticLight.cs
+++ b/Source/Client/Lights/StaticLight.cs
@@ -35,7 +35,7 @@
 #endregion
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using CodeImp.Bloodmasters.Client.Graphics;
 using SharpDX;
@@ -96,11 +96,11 @@ namespace CodeImp.Bloodmasters.Client
 		private float wallslightmapunit;
 
 		// List of nearby sectors
-		private ArrayList sectors = new ArrayList();
+		private List<VisualSector> sectors = new();
 
 		// List of nearby sides
-		private ArrayList sides = new ArrayList();
-		private ArrayList visualsides = new ArrayList();
+		private List<ClientSidedef> sides = new();
+		private List<VisualSidedef> visualsides = new();
 
 		#endregion
 
@@ -120,7 +120,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Constructor / Destructor
 
 		// Constructor
-		public StaticLight(Thing t, ArrayList vsectors, bool shadows)
+		public StaticLight(Thing t, IReadOnlyList<VisualSector> vsectors, bool shadows)
 		{
 			// Keep properties
 			this.thingindex = t.Index;
@@ -137,7 +137,7 @@ namespace CodeImp.Bloodmasters.Client
 
 		// Constructor
 		public StaticLight(float x, float y, float z, float range, int basecolor,
-					int template, ArrayList vsectors, bool shadows, bool permanent)
+					int template, IReadOnlyList<VisualSector> vsectors, bool shadows, bool permanent)
 		{
 			// Keep properties
 			this.thingindex = -1;
@@ -152,10 +152,10 @@ namespace CodeImp.Bloodmasters.Client
 
 		// This sets up the light
 		private void SetupLight(float x, float y, float z, Sector sector,
-								float range, int basecolor, ArrayList vsectors, int template)
+								float range, int basecolor, IReadOnlyList<VisualSector> vsectors, int template)
 		{
 			ClientSidedef s;
-			ArrayList lines;
+            List<Linedef> lines;
 
 			// Properties for all lights
 			this.x = x;
@@ -187,7 +187,7 @@ namespace CodeImp.Bloodmasters.Client
 			for(int i = 0; i < vsectors.Count; i++)
 			{
 				// Get VisualSector
-				VisualSector vs = (VisualSector)vsectors[i];
+				VisualSector vs = vsectors[i];
 
 				// Check if this light can be seen from the sector
 				if(vs.CanBeVisible(sector.Index))
@@ -209,7 +209,7 @@ namespace CodeImp.Bloodmasters.Client
 			for(int l = lines.Count - 1; l >= 0; l--)
 			{
 				// Get the line
-				Linedef ld = (Linedef)lines[l];
+				Linedef ld = lines[l];
 
 				// Check side of line
 				float side = ld.SideOfLine(x, y);
@@ -776,7 +776,7 @@ namespace CodeImp.Bloodmasters.Client
 				System.Drawing.Color c = System.Drawing.Color.FromArgb(color);
 
 				// Determine alpha component
-				float ca = StaticLight.CalculateHeightAlpha((Sector)vs.Sectors[0], this.z);
+				float ca = StaticLight.CalculateHeightAlpha(vs.Sectors[0], this.z);
 
 				// Make vertex colors
 				int vc = System.Drawing.Color.FromArgb((int)(ca * 255f), c).ToArgb();

--- a/Source/Client/Projectiles/IonBall.cs
+++ b/Source/Client/Projectiles/IonBall.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using SharpDX.Direct3D9;
 
 namespace CodeImp.Bloodmasters.Client
@@ -30,7 +30,7 @@ namespace CodeImp.Bloodmasters.Client
 		private Sprite sprite;
 		private ISound flying;
 		private DynamicLight light;
-		private ArrayList lightnings = new ArrayList();
+		private List<Lightning> lightnings = new();
 		private int particletime;
 
 		#endregion
@@ -349,7 +349,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// Dispose them all
 				for(int i = lightnings.Count - 1; i >= 0; i--)
-					((Lightning)lightnings[i]).Dispose();
+					lightnings[i].Dispose();
 			}
 		}
 

--- a/Source/Client/Projectiles/ProjectileInfo.cs
+++ b/Source/Client/Projectiles/ProjectileInfo.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp.Bloodmasters;
 using CodeImp;
 
@@ -18,10 +17,10 @@ namespace CodeImp.Bloodmasters.Client
 	{
 		// Members
 		private PROJECTILE type;
-		
+
 		// Properties
 		public PROJECTILE Type { get { return type; } }
-		
+
 		// Constructor
 		public ProjectileInfo(PROJECTILE type)
 		{

--- a/Source/Client/Sound/Jukebox.cs
+++ b/Source/Client/Sound/Jukebox.cs
@@ -5,7 +5,7 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
+using System;
 using System.IO;
 
 namespace CodeImp.Bloodmasters.Client
@@ -68,10 +68,8 @@ namespace CodeImp.Bloodmasters.Client
 			else
 			{
 				// Sort list alphabetically
-				ArrayList sorter = new ArrayList(playlist);
-				sorter.Sort();
-				playlist = (string[])sorter.ToArray(typeof(string));
-			}
+                Array.Sort(playlist);
+            }
 
 			// Start playing the first track
 			if(playlist.Length > 0)

--- a/Source/Client/Sound/Sound.cs
+++ b/Source/Client/Sound/Sound.cs
@@ -63,10 +63,10 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// Clone constructor for positional sound
-		public Sound(Sound clonesnd, bool positional)
+		public Sound(ISound clonesnd, bool positional)
 		{
 			// Keep the filename
-			this.filename = clonesnd.filename;
+			this.filename = clonesnd.Filename;
 
 			// TODO[#16]: Clone the sound
 			// snd = clonesnd.snd.Clone(DirectSound.dsd);

--- a/Source/Launcher/General/Direct3D.cs
+++ b/Source/Launcher/General/Direct3D.cs
@@ -6,7 +6,6 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using SharpDX.Direct3D9;

--- a/Source/Launcher/General/IP2Country.cs
+++ b/Source/Launcher/General/IP2Country.cs
@@ -9,8 +9,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Globalization;
-using System.Collections;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Net;
 
 namespace CodeImp
@@ -18,50 +17,50 @@ namespace CodeImp
 	public class IP2Country
 	{
 		#region ================== Variables
-		
+
 		// This holds a list of IP ranges
 		private IPRangeInfo[] ipranges;
-		
+
 		#endregion
-		
+
 		#region ================== Properties
-		
+
 		public int NumRanges { get { return ipranges.Length; } }
-		
+
 		#endregion
-		
+
 		#region ================== Constructor / Destructor
-		
+
 		// This creates an empty lookup table
 		public IP2Country()
 		{
 			// Empty array
-			ipranges = new IPRangeInfo[0];
+			ipranges = Array.Empty<IPRangeInfo>();
 		}
-		
+
 		// This initializes the lookup table with the given input file
 		public IP2Country(string csvfile)
 		{
-			ArrayList iprangeslist = new ArrayList(100000);
+			List<IPRangeInfo> iprangeslist = new List<IPRangeInfo>(100000);
 			IPRangeInfo r;
 			string line;
 			string[] items;
-			
+
 			// Check if the csv file exists
 			if(File.Exists(csvfile))
 			{
 				// Open the csv file
 				FileStream csv = File.Open(csvfile, FileMode.Open, FileAccess.Read, FileShare.Read);
-				
+
 				// Create reader
 				StreamReader csvReader = new StreamReader(csv, Encoding.ASCII);
-				
+
 				// Read all lines of the file
 				while((line = csvReader.ReadLine()) != null)
 				{
 					// Split the line by its commas
 					items = line.Split(',');
-					
+
 					// Create range struct
 					r = new IPRangeInfo();
 					r.from = Convert.ToInt64(items[0].Replace("\"", ""));
@@ -69,35 +68,35 @@ namespace CodeImp
 					r.ccode1 = items[2].Replace("\"", "").ToCharArray();
 					r.ccode2 = items[3].Replace("\"", "").ToCharArray();
 					r.country = items[4].Replace("\"", "");
-					
+
 					// Add struct to array
 					iprangeslist.Add(r);
 				}
-				
-				// Convert the array to IPRangeInfo[]
-				ipranges = (IPRangeInfo[])iprangeslist.ToArray(typeof(IPRangeInfo));
+
+				// Convert the list to IPRangeInfo[]
+				ipranges = iprangeslist.ToArray();
 			}
 			else
 			{
 				// Empty array
-				ipranges = new IPRangeInfo[0];
-				
+				ipranges = Array.Empty<IPRangeInfo>();
+
 				/*
 				// File not found
 				throw(new FileNotFoundException("Unable to find the required ip-to-country CSV file."));
 				*/
 			}
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Private Methods
-		
+
 		// This makes a proper titled string
 		private string ProperCountryName(string name)
 		{
 			string newname;
-			
+
 			// Make the country name nicely
 			newname = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLower());
 			newname = newname.Replace(" And ", " and ");
@@ -106,49 +105,49 @@ namespace CodeImp
 			newname = newname.Replace(" D'", " d'");
 			return newname;
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Lookup Methods
-		
+
 		// This finds and returns country information for the given IP address
 		public IPRangeInfo LookupIP(string ipaddress)
 		{
 			IPRangeInfo item;
 			IPRangeInfo unknown = new IPRangeInfo(0, 0, "", "", "Location unknown");
-			
+
 			// Parse ip address
 			IPAddress ip = IPAddress.Parse(ipaddress);
-			
+
 			// Create long value for comparision
 			byte[] ipbytes = ip.GetAddressBytes();
 			long ipnumber = (long)ipbytes[0] * 16777216L + (long)ipbytes[1] * 65536L + (long)ipbytes[2] * 256L + (long)ipbytes[3];
-			
+
 			// Initialize start points for search
 			int mid;
 			int left = 0;
 			int right = ipranges.Length - 1;
-			
+
 			// Do a binary search for the range that starts with this value
 			while(left <= right)
 			{
 				// Get the middle item
 				mid = (left + right) / 2;
 				item = ipranges[mid];
-				
+
 				// Compare item and value
 				if(ipnumber == item.from)
 				{
 					// Make the country name nicely
 					item.country = ProperCountryName(item.country);
-					
+
 					// Return this range info
 					return item;
 				}
 				else if(ipnumber < item.from) right = mid - 1;
 				else left = mid + 1;
 			}
-			
+
 			// If no range started with this value, then
 			// left is just after the range where it should be.
 			// So backtrack a bit until correct range found.
@@ -156,25 +155,25 @@ namespace CodeImp
 			{
 				// Go back
 				left--;
-				
+
 				// Check if valid item
 				if(left < 0)
 				{
 					// Return unknown range
 					return unknown;
 				}
-				
+
 				// Get the item
 				item = ipranges[left];
 			}
 			while(item.from > ipnumber);
-			
+
 			// Check if	the IP is truly in this range
 			if(item.to >= ipnumber)
 			{
 				// Make the country name nicely
 				item.country = ProperCountryName(item.country);
-				
+
 				// Return this range info
 				return item;
 			}
@@ -184,7 +183,7 @@ namespace CodeImp
 				return unknown;
 			}
 		}
-		
+
 		#endregion
 	}
 }

--- a/Source/Launcher/General/IPRangeInfo.cs
+++ b/Source/Launcher/General/IPRangeInfo.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Text;
 using System.Globalization;
-using System.Collections;
 using System.Collections.Specialized;
 
 namespace CodeImp
@@ -27,7 +26,7 @@ namespace CodeImp
 			ccode2 = pccode2.ToCharArray();
 			country = pcountry;
 		}
-		
+
 		// Members
 		public long from;
 		public long to;

--- a/Source/Launcher/Interface/FormDownload.cs
+++ b/Source/Launcher/Interface/FormDownload.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Net;
@@ -12,7 +11,7 @@ namespace CodeImp.Bloodmasters.Launcher
 	public class FormDownload : System.Windows.Forms.Form
 	{
 		private const int READ_BLOCK = 1024;
-		
+
 		private System.Windows.Forms.Label lblStatus;
 		private System.Windows.Forms.ProgressBar prgStatus;
 		private System.Windows.Forms.Button btnCancel;
@@ -21,17 +20,17 @@ namespace CodeImp.Bloodmasters.Launcher
 		private System.Windows.Forms.Timer tmrStart;
 		private bool cancelled;
 		private string fileurl;
-		
+
 		// Constructor
 		public FormDownload(GamesListItem server)
 		{
 			// Required for Windows Form Designer support
 			InitializeComponent();
-			
+
 			// Initialize
 			this.server = server;
 		}
-		
+
 		// Clean up any resources used.
 		protected override void Dispose( bool disposing )
 		{
@@ -55,24 +54,24 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnCancel = new System.Windows.Forms.Button();
 			this.tmrStart = new System.Windows.Forms.Timer(this.components);
 			this.SuspendLayout();
-			// 
+			//
 			// lblStatus
-			// 
+			//
 			this.lblStatus.Location = new System.Drawing.Point(12, 16);
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(308, 16);
 			this.lblStatus.TabIndex = 0;
 			this.lblStatus.Text = "Searching server website for map download...";
-			// 
+			//
 			// prgStatus
-			// 
+			//
 			this.prgStatus.Location = new System.Drawing.Point(12, 36);
 			this.prgStatus.Name = "prgStatus";
 			this.prgStatus.Size = new System.Drawing.Size(360, 20);
 			this.prgStatus.TabIndex = 1;
-			// 
+			//
 			// btnCancel
-			// 
+			//
 			this.btnCancel.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
 			this.btnCancel.Location = new System.Drawing.Point(256, 68);
 			this.btnCancel.Name = "btnCancel";
@@ -80,14 +79,14 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnCancel.TabIndex = 2;
 			this.btnCancel.Text = "Cancel";
 			this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-			// 
+			//
 			// tmrStart
-			// 
+			//
 			this.tmrStart.Interval = 200;
 			this.tmrStart.Tick += new System.EventHandler(this.tmrStart_Tick);
-			// 
+			//
 			// FormDownload
-			// 
+			//
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.ClientSize = new System.Drawing.Size(382, 107);
 			this.ControlBox = false;
@@ -106,13 +105,13 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		}
 		#endregion
-		
+
 		// Cancel clicked
 		private void btnCancel_Click(object sender, System.EventArgs e)
 		{
 			cancelled = true;
 		}
-		
+
 		// This searches
 		public bool Search()
 		{
@@ -123,11 +122,11 @@ namespace CodeImp.Bloodmasters.Launcher
 			byte[] data = new byte[READ_BLOCK];
 			int contentlength, numread, newpos, endpos, lastpos = 0;
 			string htmltext, htmltextlower;
-			
+
 			// Display status
 			lblStatus.Text = "Searching server website for " + server.MapName + ".rar...";
 			lblStatus.Update();
-			
+
 			// Server URL is what we are looking for?
 			if(server.Website.ToLower().EndsWith(server.MapName.ToLower() + ".rar"))
 			{
@@ -138,7 +137,7 @@ namespace CodeImp.Bloodmasters.Launcher
 					return true;
 				}
 			}
-			
+
 			try
 			{
 				// Download the website HTML
@@ -150,29 +149,29 @@ namespace CodeImp.Bloodmasters.Launcher
 			{
 				// Clean up
 				if(resp != null) resp.Close();
-				
+
 				// Cant download
 				MessageBox.Show(this, "Unable to contact the server website. The website URL may be invalid or the website is experiencing technical difficulties.", "Downloading", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 				return false;
 			}
-			
+
 			// Set progress bar
 			contentlength = (int)resp.ContentLength;
 			if(contentlength > 0) prgStatus.Maximum = contentlength;
-			
+
 			// Make a memory stream for the download
 			html = new MemoryStream();
-			
+
 			// Get the http download
 			download = resp.GetResponseStream();
-			
+
 			// Read the whole stream
 			do
 			{
 				// Try reading 1 KB
 				numread = -1;
 				try { numread = download.Read(data, 0, READ_BLOCK); } catch(Exception e) { }
-				
+
 				// Anything new?
 				if(numread > 0)
 				{
@@ -180,7 +179,7 @@ namespace CodeImp.Bloodmasters.Launcher
 					html.Write(data, 0, numread);
 					if((int)html.Length <= prgStatus.Maximum) prgStatus.Value = (int)html.Length;
 				}
-				
+
 				// Allow cancel
 				Application.DoEvents();
 				if(cancelled)
@@ -193,75 +192,75 @@ namespace CodeImp.Bloodmasters.Launcher
 				}
 			}
 			while(html.Length < resp.ContentLength);
-			
+
 			// Make text string
 			htmltext = Encoding.ASCII.GetString(html.ToArray());
 			htmltextlower = htmltext.ToLower();
-			
+
 			// Clean up
 			html.Close();
 			download.Close();
 			resp.Close();
-			
+
 			do
 			{
 				// Find a "<a" tag
 				newpos = htmltextlower.IndexOf("<a", lastpos);
-				
+
 				// Found anything?
 				if(newpos > -1)
 				{
 					// Find the end of the tag ">"
 					lastpos = htmltextlower.IndexOf(">", newpos);
-					
+
 					// If there is no end, use the end of the file
 					if(lastpos == -1) lastpos = htmltext.Length - 1;
-					
+
 					// Find the "href" part
 					endpos = htmltextlower.IndexOf("href", newpos);
 					if(endpos > lastpos) continue;
-					
+
 					// Find the =
 					endpos = htmltext.IndexOf("=", endpos);
 					if(endpos > lastpos) continue;
-					
+
 					// Skip any whitespace
 					endpos++;
 					while((htmltext[endpos] == ' ') || (htmltext[endpos] == '\t') ||
 					      (htmltext[endpos] == '\n') || (htmltext[endpos] == '\r')) endpos++;
 					if(endpos > lastpos) continue;
-					
+
 					// Set position where URL starts
 					newpos = endpos;
-					
+
 					// Find the next space
 					endpos = htmltext.IndexOfAny(new char[]{' ', '\t', '\r', '\n' }, newpos);
 					if(endpos > lastpos) endpos = lastpos;
-					
+
 					// Remove any quotes
 					fileurl = htmltext.Substring(newpos, endpos - newpos);
 					fileurl = fileurl.Replace("\"", "");
 					fileurl = fileurl.Replace("\'", "");
-					
+
 					// URL we are looking for?
 					if(fileurl.ToLower().EndsWith(server.MapName.ToLower() + ".rar"))
 					{
 						// Make the url absolute
 						if(!fileurl.ToLower().StartsWith("http://"))
 							fileurl = Path.Combine(server.Website, fileurl);
-							
+
 						// Found!
 						return true;
 					}
 				}
 			}
 			while(newpos > -1);
-			
+
 			// Nothing found
 			MessageBox.Show(this, "The download link for the map " + server.MapName + ".rar could not be found on the website provided by the server.", "Downloading", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 			return false;
 		}
-		
+
 		// This downloads
 		private bool Download()
 		{
@@ -272,15 +271,15 @@ namespace CodeImp.Bloodmasters.Launcher
 			byte[] data = new byte[READ_BLOCK];
 			string filename;
 			int contentlength, numread;
-			
+
 			// Display status
 			lblStatus.Text = "Downloading map " + server.MapName + ".rar...";
 			lblStatus.Update();
-			
+
 			// Set progress bar
 			prgStatus.Value = 0;
 			prgStatus.Maximum = 1;
-			
+
 			try
 			{
 				// Download the website HTML
@@ -292,30 +291,30 @@ namespace CodeImp.Bloodmasters.Launcher
 			{
 				// Clean up
 				if(resp != null) resp.Close();
-				
+
 				// Cant download
 				MessageBox.Show(this, "Unable to contact the download website. The file URL may be invalid or the website is experiencing technical difficulties.", "Downloading", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 				return false;
 			}
-			
+
 			// Set progress bar
 			contentlength = (int)resp.ContentLength;
 			if(contentlength > 0) prgStatus.Maximum = contentlength;
-			
+
 			// Make the file
 			filename = Path.Combine(General.apppath, server.MapName + ".rar");
 			file = File.Open(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-			
+
 			// Get the http download
 			download = resp.GetResponseStream();
-			
+
 			// Read the whole stream
 			do
 			{
 				// Try reading 1 KB
 				numread = -1;
 				try { numread = download.Read(data, 0, READ_BLOCK); } catch(Exception e) { }
-				
+
 				// Anything new?
 				if(numread > 0)
 				{
@@ -323,7 +322,7 @@ namespace CodeImp.Bloodmasters.Launcher
 					file.Write(data, 0, numread);
 					if((int)file.Length <= prgStatus.Maximum) prgStatus.Value = (int)file.Length;
 				}
-				
+
 				// Allow cancel
 				Application.DoEvents();
 				if(cancelled)
@@ -337,17 +336,17 @@ namespace CodeImp.Bloodmasters.Launcher
 				}
 			}
 			while(file.Length < resp.ContentLength);
-			
+
 			// Clean up
 			file.Flush();
 			file.Close();
 			download.Close();
 			resp.Close();
-			
+
 			// Success!
 			return true;
 		}
-		
+
 		// When appearing
 		private void FormDownload_VisibleChanged(object sender, System.EventArgs e)
 		{
@@ -359,7 +358,7 @@ namespace CodeImp.Bloodmasters.Launcher
 		{
 			// Stop timer
 			tmrStart.Enabled = false;
-			
+
 			// Make sure window is refreshed
 			this.Update();
 			if(this.Search())

--- a/Source/Launcher/Interface/FormError.cs
+++ b/Source/Launcher/Interface/FormError.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 using CodeImp.Bloodmasters;
@@ -25,14 +24,14 @@ namespace CodeImp.Bloodmasters.Launcher
 		public System.Windows.Forms.Label lblTitle;
 		public System.Windows.Forms.Label lblMessage;
 		public System.Windows.Forms.TextBox txtCallStack;
-		
+
 		// Constructor
 		public FormError()
 		{
 			// Required for Windows Form Designer support
 			InitializeComponent();
 		}
-		
+
 		// Clean up any resources being used.
 		protected override void Dispose( bool disposing )
 		{
@@ -42,11 +41,11 @@ namespace CodeImp.Bloodmasters.Launcher
 				// Dispose components, if any
 				if(components != null) components.Dispose();
 			}
-			
+
 			// Let superior class know about the dispose
 			base.Dispose(disposing);
 		}
-		
+
 		#region Windows Form Designer generated code
 		private void InitializeComponent()
 		{
@@ -58,9 +57,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.txtCallStack = new System.Windows.Forms.TextBox();
 			this.btnClose = new System.Windows.Forms.Button();
 			this.SuspendLayout();
-			// 
+			//
 			// picIcon
-			// 
+			//
 			this.picIcon.Image = ((System.Drawing.Image)(resources.GetObject("picIcon.Image")));
 			this.picIcon.Location = new System.Drawing.Point(16, 12);
 			this.picIcon.Name = "picIcon";
@@ -68,10 +67,10 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.picIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
 			this.picIcon.TabIndex = 0;
 			this.picIcon.TabStop = false;
-			// 
+			//
 			// lblTitle
-			// 
-			this.lblTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.lblTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lblTitle.FlatStyle = System.Windows.Forms.FlatStyle.System;
 			this.lblTitle.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
@@ -81,10 +80,10 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblTitle.TabIndex = 1;
 			this.lblTitle.Text = "Bloodmasters engine throws the following ";
 			this.lblTitle.UseMnemonic = false;
-			// 
+			//
 			// lblMessage
-			// 
-			this.lblMessage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.lblMessage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lblMessage.FlatStyle = System.Windows.Forms.FlatStyle.System;
 			this.lblMessage.Location = new System.Drawing.Point(56, 28);
@@ -93,10 +92,10 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblMessage.TabIndex = 2;
 			this.lblMessage.Text = "BlaException bladieblaap cannot be found and such.";
 			this.lblMessage.UseMnemonic = false;
-			// 
+			//
 			// label1
-			// 
-			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.label1.AutoSize = true;
 			this.label1.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -107,11 +106,11 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.label1.TabIndex = 3;
 			this.label1.Text = "Error report information:";
 			this.label1.UseMnemonic = false;
-			// 
+			//
 			// txtCallStack
-			// 
-			this.txtCallStack.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-				| System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.txtCallStack.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+				| System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.txtCallStack.Location = new System.Drawing.Point(56, 80);
 			this.txtCallStack.Multiline = true;
@@ -122,9 +121,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.txtCallStack.TabIndex = 0;
 			this.txtCallStack.Text = "Calls";
 			this.txtCallStack.WordWrap = false;
-			// 
+			//
 			// btnClose
-			// 
+			//
 			this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
 			this.btnClose.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -134,9 +133,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnClose.TabIndex = 2;
 			this.btnClose.Text = "Close";
 			this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
-			// 
+			//
 			// FormError
-			// 
+			//
 			this.AcceptButton = this.btnClose;
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.CancelButton = this.btnClose;
@@ -157,7 +156,7 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		}
 		#endregion
-		
+
 		// Close clicked
 		private void btnClose_Click(object sender, System.EventArgs e)
 		{

--- a/Source/Launcher/Interface/FormGameInfo.cs
+++ b/Source/Launcher/Interface/FormGameInfo.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Drawing;
 using System.Net;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Diagnostics;
@@ -66,35 +65,35 @@ namespace CodeImp.Bloodmasters.Launcher
 		private int lastrevision;
 		private System.Windows.Forms.Label lblBuildDescription;
 		private GamesListItem item;
-		
+
 		// Constructor
 		public FormGameInfo(GamesListItem item)
 		{
 			// Required for Windows Form Designer support
 			InitializeComponent();
-			
+
 			// Keep item
 			this.item = item;
 			UpdateSettings();
 		}
-		
+
 		// Clean up any resources being used.
 		protected override void Dispose(bool disposing)
 		{
 			// Destroy references
 			item = null;
-			
+
 			// Check if disposing
 			if(disposing)
 			{
 				// Dispose components, if any
 				if(components != null) components.Dispose();
 			}
-			
+
 			// Let superior class know about the dispose
 			base.Dispose(disposing);
 		}
-		
+
 		#region Windows Form Designer generated code
 		/// <summary>
 		/// Required method for Designer support - do not modify
@@ -152,10 +151,10 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pnlProtocol.SuspendLayout();
 			this.pnlLocked.SuspendLayout();
 			this.SuspendLayout();
-			// 
+			//
 			// lblTitle
-			// 
-			this.lblTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.lblTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lblTitle.BackColor = System.Drawing.Color.Transparent;
 			this.lblTitle.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
@@ -166,18 +165,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblTitle.TabIndex = 0;
 			this.lblTitle.Text = "Title";
 			this.lblTitle.UseMnemonic = false;
-			// 
+			//
 			// label1
-			// 
+			//
 			this.label1.Location = new System.Drawing.Point(180, 148);
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(48, 16);
 			this.label1.TabIndex = 1;
 			this.label1.Text = "Players:";
 			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblPlayers
-			// 
+			//
 			this.lblPlayers.AutoSize = true;
 			this.lblPlayers.Location = new System.Drawing.Point(228, 148);
 			this.lblPlayers.Name = "lblPlayers";
@@ -185,18 +184,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblPlayers.TabIndex = 2;
 			this.lblPlayers.Text = "0";
 			this.lblPlayers.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label2
-			// 
+			//
 			this.label2.Location = new System.Drawing.Point(256, 148);
 			this.label2.Name = "label2";
 			this.label2.Size = new System.Drawing.Size(56, 16);
 			this.label2.TabIndex = 3;
 			this.label2.Text = "Maximum:";
 			this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblMaxPlayers
-			// 
+			//
 			this.lblMaxPlayers.AutoSize = true;
 			this.lblMaxPlayers.Location = new System.Drawing.Point(312, 148);
 			this.lblMaxPlayers.Name = "lblMaxPlayers";
@@ -204,9 +203,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblMaxPlayers.TabIndex = 4;
 			this.lblMaxPlayers.Text = "0";
 			this.lblMaxPlayers.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// lblMaxClients
-			// 
+			//
 			this.lblMaxClients.AutoSize = true;
 			this.lblMaxClients.Location = new System.Drawing.Point(312, 124);
 			this.lblMaxClients.Name = "lblMaxClients";
@@ -214,18 +213,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblMaxClients.TabIndex = 8;
 			this.lblMaxClients.Text = "0";
 			this.lblMaxClients.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label4
-			// 
+			//
 			this.label4.Location = new System.Drawing.Point(256, 124);
 			this.label4.Name = "label4";
 			this.label4.Size = new System.Drawing.Size(56, 16);
 			this.label4.TabIndex = 7;
 			this.label4.Text = "Maximum:";
 			this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblClients
-			// 
+			//
 			this.lblClients.AutoSize = true;
 			this.lblClients.Location = new System.Drawing.Point(228, 124);
 			this.lblClients.Name = "lblClients";
@@ -233,18 +232,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblClients.TabIndex = 6;
 			this.lblClients.Text = "0";
 			this.lblClients.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label6
-			// 
+			//
 			this.label6.Location = new System.Drawing.Point(180, 124);
 			this.label6.Name = "label6";
 			this.label6.Size = new System.Drawing.Size(48, 16);
 			this.label6.TabIndex = 5;
 			this.label6.Text = "Clients:";
 			this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// btnClose
-			// 
+			//
 			this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
 			this.btnClose.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -255,19 +254,19 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnClose.TabIndex = 1;
 			this.btnClose.Text = "Close";
 			this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
-			// 
+			//
 			// groupBox1
-			// 
-			this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.groupBox1.Location = new System.Drawing.Point(12, 36);
 			this.groupBox1.Name = "groupBox1";
 			this.groupBox1.Size = new System.Drawing.Size(356, 7);
 			this.groupBox1.TabIndex = 10;
 			this.groupBox1.TabStop = false;
-			// 
+			//
 			// lblFraglimit
-			// 
+			//
 			this.lblFraglimit.AutoSize = true;
 			this.lblFraglimit.Location = new System.Drawing.Point(60, 4);
 			this.lblFraglimit.Name = "lblFraglimit";
@@ -275,18 +274,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblFraglimit.TabIndex = 12;
 			this.lblFraglimit.Text = "0";
 			this.lblFraglimit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label5
-			// 
+			//
 			this.label5.Location = new System.Drawing.Point(0, 4);
 			this.label5.Name = "label5";
 			this.label5.Size = new System.Drawing.Size(60, 16);
 			this.label5.TabIndex = 11;
 			this.label5.Text = "Scorelimit:";
 			this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblTimelimit
-			// 
+			//
 			this.lblTimelimit.AutoSize = true;
 			this.lblTimelimit.Location = new System.Drawing.Point(60, 28);
 			this.lblTimelimit.Name = "lblTimelimit";
@@ -294,18 +293,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblTimelimit.TabIndex = 14;
 			this.lblTimelimit.Text = "0";
 			this.lblTimelimit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label7
-			// 
+			//
 			this.label7.Location = new System.Drawing.Point(4, 28);
 			this.label7.Name = "label7";
 			this.label7.Size = new System.Drawing.Size(56, 16);
 			this.label7.TabIndex = 13;
 			this.label7.Text = "Timelimit:";
 			this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblGameType
-			// 
+			//
 			this.lblGameType.AutoSize = true;
 			this.lblGameType.Location = new System.Drawing.Point(68, 124);
 			this.lblGameType.Name = "lblGameType";
@@ -313,18 +312,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblGameType.TabIndex = 18;
 			this.lblGameType.Text = "Deathmatch";
 			this.lblGameType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label9
-			// 
+			//
 			this.label9.Location = new System.Drawing.Point(24, 124);
 			this.label9.Name = "label9";
 			this.label9.Size = new System.Drawing.Size(44, 16);
 			this.label9.TabIndex = 17;
 			this.label9.Text = "Game:";
 			this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblMap
-			// 
+			//
 			this.lblMap.AutoSize = true;
 			this.lblMap.Location = new System.Drawing.Point(68, 148);
 			this.lblMap.Name = "lblMap";
@@ -332,18 +331,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblMap.TabIndex = 20;
 			this.lblMap.Text = "Test";
 			this.lblMap.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label10
-			// 
+			//
 			this.label10.Location = new System.Drawing.Point(24, 148);
 			this.label10.Name = "label10";
 			this.label10.Size = new System.Drawing.Size(44, 16);
 			this.label10.TabIndex = 19;
 			this.label10.Text = "Map:";
 			this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblJoinSmallest
-			// 
+			//
 			this.lblJoinSmallest.AutoSize = true;
 			this.lblJoinSmallest.Location = new System.Drawing.Point(304, 28);
 			this.lblJoinSmallest.Name = "lblJoinSmallest";
@@ -351,29 +350,29 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblJoinSmallest.TabIndex = 24;
 			this.lblJoinSmallest.Text = "0";
 			this.lblJoinSmallest.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// label11
-			// 
+			//
 			this.label11.Location = new System.Drawing.Point(164, 28);
 			this.label11.Name = "label11";
 			this.label11.Size = new System.Drawing.Size(140, 16);
 			this.label11.TabIndex = 23;
 			this.label11.Text = "Always join smallest team:";
 			this.label11.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// groupBox2
-			// 
-			this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.groupBox2.Location = new System.Drawing.Point(4, 56);
 			this.groupBox2.Name = "groupBox2";
 			this.groupBox2.Size = new System.Drawing.Size(356, 7);
 			this.groupBox2.TabIndex = 25;
 			this.groupBox2.TabStop = false;
-			// 
+			//
 			// lstPlayers
-			// 
-			this.lstPlayers.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.lstPlayers.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lstPlayers.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
 																						 this.clmPLayerName,
@@ -387,40 +386,40 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lstPlayers.Size = new System.Drawing.Size(356, 156);
 			this.lstPlayers.TabIndex = 3;
 			this.lstPlayers.View = System.Windows.Forms.View.Details;
-			// 
+			//
 			// clmPLayerName
-			// 
+			//
 			this.clmPLayerName.Text = "Name";
 			this.clmPLayerName.Width = 124;
-			// 
+			//
 			// clmPlayerTeam
-			// 
+			//
 			this.clmPlayerTeam.Text = "Team";
 			this.clmPlayerTeam.Width = 64;
-			// 
+			//
 			// clmPlayerSpect
-			// 
+			//
 			this.clmPlayerSpect.Text = "Mode";
 			this.clmPlayerSpect.Width = 86;
-			// 
+			//
 			// clmPlayerPing
-			// 
+			//
 			this.clmPlayerPing.Text = "Ping";
 			this.clmPlayerPing.Width = 50;
-			// 
+			//
 			// label12
-			// 
+			//
 			this.label12.Location = new System.Drawing.Point(16, 76);
 			this.label12.Name = "label12";
 			this.label12.Size = new System.Drawing.Size(52, 16);
 			this.label12.TabIndex = 27;
 			this.label12.Text = "Website:";
 			this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblWebsite
-			// 
+			//
 			this.lblWebsite.ActiveLinkColor = System.Drawing.Color.Blue;
-			this.lblWebsite.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.lblWebsite.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.lblWebsite.AutoSize = true;
 			this.lblWebsite.Cursor = System.Windows.Forms.Cursors.Hand;
@@ -436,10 +435,10 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblWebsite.UseMnemonic = false;
 			this.lblWebsite.VisitedLinkColor = System.Drawing.Color.Purple;
 			this.lblWebsite.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lblWebsite_LinkClicked);
-			// 
+			//
 			// pnlExtended
-			// 
-			this.pnlExtended.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			//
+			this.pnlExtended.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
 			this.pnlExtended.Controls.Add(this.lblJoinSmallest);
 			this.pnlExtended.Controls.Add(this.label11);
@@ -453,9 +452,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pnlExtended.Name = "pnlExtended";
 			this.pnlExtended.Size = new System.Drawing.Size(364, 232);
 			this.pnlExtended.TabIndex = 30;
-			// 
+			//
 			// pnlProtocol
-			// 
+			//
 			this.pnlProtocol.BackColor = System.Drawing.SystemColors.Info;
 			this.pnlProtocol.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.pnlProtocol.Controls.Add(this.lblProtocol);
@@ -465,18 +464,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pnlProtocol.Size = new System.Drawing.Size(356, 24);
 			this.pnlProtocol.TabIndex = 31;
 			this.pnlProtocol.Visible = false;
-			// 
+			//
 			// lblProtocol
-			// 
+			//
 			this.lblProtocol.ForeColor = System.Drawing.SystemColors.InfoText;
 			this.lblProtocol.Location = new System.Drawing.Point(24, 4);
 			this.lblProtocol.Name = "lblProtocol";
 			this.lblProtocol.Size = new System.Drawing.Size(336, 16);
 			this.lblProtocol.TabIndex = 1;
 			this.lblProtocol.Text = "Protocol error";
-			// 
+			//
 			// pictureBox1
-			// 
+			//
 			this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
 			this.pictureBox1.Location = new System.Drawing.Point(0, 0);
 			this.pictureBox1.Name = "pictureBox1";
@@ -484,9 +483,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
 			this.pictureBox1.TabIndex = 0;
 			this.pictureBox1.TabStop = false;
-			// 
+			//
 			// pnlLocked
-			// 
+			//
 			this.pnlLocked.BackColor = System.Drawing.SystemColors.Info;
 			this.pnlLocked.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.pnlLocked.Controls.Add(this.lblLocked);
@@ -496,18 +495,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pnlLocked.Size = new System.Drawing.Size(356, 24);
 			this.pnlLocked.TabIndex = 32;
 			this.pnlLocked.Visible = false;
-			// 
+			//
 			// lblLocked
-			// 
+			//
 			this.lblLocked.ForeColor = System.Drawing.SystemColors.InfoText;
 			this.lblLocked.Location = new System.Drawing.Point(24, 4);
 			this.lblLocked.Name = "lblLocked";
 			this.lblLocked.Size = new System.Drawing.Size(336, 16);
 			this.lblLocked.TabIndex = 1;
 			this.lblLocked.Text = "This server is locked with a password.";
-			// 
+			//
 			// pictureBox2
-			// 
+			//
 			this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
 			this.pictureBox2.Location = new System.Drawing.Point(0, 1);
 			this.pictureBox2.Name = "pictureBox2";
@@ -515,9 +514,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
 			this.pictureBox2.TabIndex = 0;
 			this.pictureBox2.TabStop = false;
-			// 
+			//
 			// chkRefresh
-			// 
+			//
 			this.chkRefresh.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.chkRefresh.Appearance = System.Windows.Forms.Appearance.Button;
 			this.chkRefresh.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -529,19 +528,19 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.chkRefresh.Text = "Auto Refresh";
 			this.chkRefresh.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			this.chkRefresh.CheckedChanged += new System.EventHandler(this.chkRefresh_CheckedChanged);
-			// 
+			//
 			// tmrRefresh
-			// 
+			//
 			this.tmrRefresh.Interval = 3000;
 			this.tmrRefresh.Tick += new System.EventHandler(this.tmrRefresh_Tick);
-			// 
+			//
 			// tmrUpdate
-			// 
+			//
 			this.tmrUpdate.Interval = 600;
 			this.tmrUpdate.Tick += new System.EventHandler(this.tmrUpdate_Tick);
-			// 
+			//
 			// btnJoin
-			// 
+			//
 			this.btnJoin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnJoin.DialogResult = System.Windows.Forms.DialogResult.OK;
 			this.btnJoin.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -552,18 +551,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnJoin.TabIndex = 0;
 			this.btnJoin.Text = "Join";
 			this.btnJoin.Click += new System.EventHandler(this.btnJoin_Click);
-			// 
+			//
 			// label3
-			// 
+			//
 			this.label3.Location = new System.Drawing.Point(16, 100);
 			this.label3.Name = "label3";
 			this.label3.Size = new System.Drawing.Size(52, 16);
 			this.label3.TabIndex = 33;
 			this.label3.Text = "Location:";
 			this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblLocation
-			// 
+			//
 			this.lblLocation.AutoSize = true;
 			this.lblLocation.Location = new System.Drawing.Point(68, 100);
 			this.lblLocation.Name = "lblLocation";
@@ -571,18 +570,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblLocation.TabIndex = 34;
 			this.lblLocation.Text = "Location unknown";
 			this.lblLocation.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// picLocation
-			// 
+			//
 			this.picLocation.BackColor = System.Drawing.Color.Transparent;
 			this.picLocation.Location = new System.Drawing.Point(70, 100);
 			this.picLocation.Name = "picLocation";
 			this.picLocation.Size = new System.Drawing.Size(16, 16);
 			this.picLocation.TabIndex = 35;
 			this.picLocation.TabStop = false;
-			// 
+			//
 			// lblBuildDescription
-			// 
+			//
 			this.lblBuildDescription.AutoSize = true;
 			this.lblBuildDescription.Location = new System.Drawing.Point(16, 48);
 			this.lblBuildDescription.Name = "lblBuildDescription";
@@ -590,9 +589,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.lblBuildDescription.TabIndex = 36;
 			this.lblBuildDescription.Text = "Unknown server type or version";
 			this.lblBuildDescription.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
+			//
 			// FormGameInfo
-			// 
+			//
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.CancelButton = this.btnClose;
 			this.ClientSize = new System.Drawing.Size(378, 443);
@@ -637,13 +636,13 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		}
 		#endregion
-		
+
 		// This updates the components to match with the game information
 		public void UpdateSettings()
 		{
 			// Lookup country information
 			IPRangeInfo cinfo = General.ip2country.LookupIP(item.Address.Address.ToString());
-			
+
 			// Setup interface with game item information
 			lastrevision = item.Revision;
 			lblTitle.Text = item.Title;
@@ -656,13 +655,13 @@ namespace CodeImp.Bloodmasters.Launcher
 			lblMaxClients.Text = item.MaxClients.ToString();
 			pnlLocked.Visible = item.Locked;
 			if(item.Locked && (pnlLocked.Bottom > btnClose.Top)) this.Height += pnlLocked.Height;
-			
+
 			// Set flag icon and location
 			//try { picLocation.Image = formmain.GetFlagIcon(cinfo.ccode1); } catch(Exception) { }
 			picLocation.Image = General.mainwindow.GetFlagIcon(cinfo.ccode1);
 			if(picLocation.Image != null) lblLocation.Left = picLocation.Right + 2;
 			lblLocation.Text = cinfo.country;
-			
+
 			// Check if protocol matches
 			if(item.Protocol == Gateway.PROTOCOL_VERSION)
 			{
@@ -670,7 +669,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				lblFraglimit.Text = item.Fraglimit.ToString();
 				lblTimelimit.Text = item.Timelimit.ToString();
 				lblJoinSmallest.Text = YesNo(item.JoinSmallest);
-				
+
 				// Go for player information
 				lstPlayers.Items.Clear();
 				for(int i = 0; i < item.Clients; i++)
@@ -683,11 +682,11 @@ namespace CodeImp.Bloodmasters.Launcher
 					else itm.SubItems.Add("Playing");
 					itm.SubItems.Add(item.PlayerPing[i] + "ms");
 					itm.SubItems[3].ForeColor = GamesListItem.MakePingColor(item.PlayerPing[i]);
-					
+
 					// Add the item to list
 					lstPlayers.Items.Add(itm);
 				}
-				
+
 				// Show build description
 				if(item.BuildDescription != null) lblBuildDescription.Text = item.BuildDescription;
 			}
@@ -708,13 +707,13 @@ namespace CodeImp.Bloodmasters.Launcher
 				lblProtocol.Text = "This server is running a newer version of Bloodmasters.";
 			}
 		}
-		
+
 		// This returns Yes for true, No for false
 		private string YesNo(bool opt)
 		{
 			if(opt) return "Yes"; else return "No";
 		}
-		
+
 		// Website link clicked
 		private void lblWebsite_LinkClicked(object sender, System.Windows.Forms.LinkLabelLinkClickedEventArgs e)
 		{
@@ -727,7 +726,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				this.Cursor = Cursors.Default;
 			}
 		}
-		
+
 		// Auto refresh changed
 		private void chkRefresh_CheckedChanged(object sender, System.EventArgs e)
 		{
@@ -735,7 +734,7 @@ namespace CodeImp.Bloodmasters.Launcher
 			tmrRefresh.Enabled = chkRefresh.Checked;
 			tmrUpdate.Enabled = chkRefresh.Checked;
 		}
-		
+
 		// Close dialog
 		private void btnClose_Click(object sender, System.EventArgs e)
 		{
@@ -743,28 +742,28 @@ namespace CodeImp.Bloodmasters.Launcher
 			tmrRefresh.Enabled = false;
 			tmrUpdate.Enabled = false;
 		}
-		
+
 		// Refresh time
 		private void tmrRefresh_Tick(object sender, System.EventArgs e)
 		{
 			// Refresh now
 			item.Refresh();
 		}
-		
+
 		// Check for item updates
 		private void tmrUpdate_Tick(object sender, System.EventArgs e)
 		{
 			// Item changed?
 			if(item.Revision > lastrevision) UpdateSettings();
 		}
-		
+
 		// Join clicked
 		private void btnJoin_Click(object sender, System.EventArgs e)
 		{
 			// Stop auto refresh
 			tmrRefresh.Enabled = false;
 			tmrUpdate.Enabled = false;
-			
+
 			// Close with OK as dialog result
 			this.DialogResult = DialogResult.OK;
 			this.Close();

--- a/Source/Launcher/Interface/FormGamePassword.cs
+++ b/Source/Launcher/Interface/FormGamePassword.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 
@@ -21,7 +20,7 @@ namespace CodeImp.Bloodmasters.Launcher
 		private System.Windows.Forms.Button btnCancel;
 		private System.Windows.Forms.Button btnJoin;
 		private System.ComponentModel.Container components = null;
-		
+
 		// Constructor
 		public FormGamePassword()
 		{
@@ -38,7 +37,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				// Dispose components, if any
 				if(components != null) components.Dispose();
 			}
-			
+
 			// Let superior class know about the dispose
 			base.Dispose(disposing);
 		}
@@ -57,9 +56,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnJoin = new System.Windows.Forms.Button();
 			this.groupBox2.SuspendLayout();
 			this.SuspendLayout();
-			// 
+			//
 			// groupBox2
-			// 
+			//
 			this.groupBox2.Controls.Add(this.txtJoinPassword);
 			this.groupBox2.Controls.Add(this.lblJoinPassword);
 			this.groupBox2.Location = new System.Drawing.Point(8, 8);
@@ -68,9 +67,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.groupBox2.TabIndex = 10;
 			this.groupBox2.TabStop = false;
 			this.groupBox2.Text = " Password ";
-			// 
+			//
 			// txtJoinPassword
-			// 
+			//
 			this.txtJoinPassword.AutoSize = false;
 			this.txtJoinPassword.Location = new System.Drawing.Point(92, 27);
 			this.txtJoinPassword.MaxLength = 50;
@@ -79,18 +78,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.txtJoinPassword.Size = new System.Drawing.Size(192, 22);
 			this.txtJoinPassword.TabIndex = 7;
 			this.txtJoinPassword.Text = "";
-			// 
+			//
 			// lblJoinPassword
-			// 
+			//
 			this.lblJoinPassword.Location = new System.Drawing.Point(4, 27);
 			this.lblJoinPassword.Name = "lblJoinPassword";
 			this.lblJoinPassword.Size = new System.Drawing.Size(84, 20);
 			this.lblJoinPassword.TabIndex = 6;
 			this.lblJoinPassword.Text = "Password:";
 			this.lblJoinPassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// btnCancel
-			// 
+			//
 			this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
 			this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -100,9 +99,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnCancel.Size = new System.Drawing.Size(104, 27);
 			this.btnCancel.TabIndex = 13;
 			this.btnCancel.Text = "Cancel";
-			// 
+			//
 			// btnJoin
-			// 
+			//
 			this.btnJoin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnJoin.DialogResult = System.Windows.Forms.DialogResult.OK;
 			this.btnJoin.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -112,9 +111,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnJoin.Size = new System.Drawing.Size(104, 27);
 			this.btnJoin.TabIndex = 12;
 			this.btnJoin.Text = "Join";
-			// 
+			//
 			// FormGamePassword
-			// 
+			//
 			this.AcceptButton = this.btnJoin;
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.CancelButton = this.btnCancel;

--- a/Source/Launcher/Interface/FormGameSpecify.cs
+++ b/Source/Launcher/Interface/FormGameSpecify.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 
@@ -26,13 +25,13 @@ namespace CodeImp.Bloodmasters.Launcher
 		private System.Windows.Forms.Button btnCancel;
 		private System.Windows.Forms.Button btnJoin;
 		private System.ComponentModel.Container components = null;
-		
+
 		// Constructor
 		public FormGameSpecify()
 		{
 			// Required for Windows Form Designer support
 			InitializeComponent();
-			
+
 			// Fill with last used settings
 			txtJoinAddress.Text = General.config.ReadSetting("joinaddress", "");
 			txtJoinPort.Text = General.config.ReadSetting("joinport", "0");
@@ -48,7 +47,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				// Dispose components, if any
 				if(components != null) components.Dispose();
 			}
-			
+
 			// Let superior class know about the dispose
 			base.Dispose(disposing);
 		}
@@ -73,9 +72,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.groupBox2.SuspendLayout();
 			this.groupBox1.SuspendLayout();
 			this.SuspendLayout();
-			// 
+			//
 			// groupBox2
-			// 
+			//
 			this.groupBox2.Controls.Add(this.txtJoinPassword);
 			this.groupBox2.Controls.Add(this.lblJoinPassword);
 			this.groupBox2.Location = new System.Drawing.Point(8, 112);
@@ -84,9 +83,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.groupBox2.TabIndex = 9;
 			this.groupBox2.TabStop = false;
 			this.groupBox2.Text = " Password ";
-			// 
+			//
 			// txtJoinPassword
-			// 
+			//
 			this.txtJoinPassword.AutoSize = false;
 			this.txtJoinPassword.Location = new System.Drawing.Point(92, 27);
 			this.txtJoinPassword.MaxLength = 50;
@@ -95,18 +94,18 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.txtJoinPassword.Size = new System.Drawing.Size(192, 22);
 			this.txtJoinPassword.TabIndex = 7;
 			this.txtJoinPassword.Text = "";
-			// 
+			//
 			// lblJoinPassword
-			// 
+			//
 			this.lblJoinPassword.Location = new System.Drawing.Point(4, 27);
 			this.lblJoinPassword.Name = "lblJoinPassword";
 			this.lblJoinPassword.Size = new System.Drawing.Size(84, 20);
 			this.lblJoinPassword.TabIndex = 6;
 			this.lblJoinPassword.Text = "Password:";
 			this.lblJoinPassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// groupBox1
-			// 
+			//
 			this.groupBox1.Controls.Add(this.txtJoinPort);
 			this.groupBox1.Controls.Add(this.txtJoinAddress);
 			this.groupBox1.Controls.Add(this.lblJoinPort);
@@ -117,45 +116,45 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.groupBox1.TabIndex = 8;
 			this.groupBox1.TabStop = false;
 			this.groupBox1.Text = " Server ";
-			// 
+			//
 			// txtJoinPort
-			// 
+			//
 			this.txtJoinPort.AutoSize = false;
 			this.txtJoinPort.Location = new System.Drawing.Point(92, 56);
 			this.txtJoinPort.Name = "txtJoinPort";
 			this.txtJoinPort.Size = new System.Drawing.Size(192, 22);
 			this.txtJoinPort.TabIndex = 8;
 			this.txtJoinPort.Text = "";
-			// 
+			//
 			// txtJoinAddress
-			// 
+			//
 			this.txtJoinAddress.AutoSize = false;
 			this.txtJoinAddress.Location = new System.Drawing.Point(92, 28);
 			this.txtJoinAddress.Name = "txtJoinAddress";
 			this.txtJoinAddress.Size = new System.Drawing.Size(192, 22);
 			this.txtJoinAddress.TabIndex = 7;
 			this.txtJoinAddress.Text = "";
-			// 
+			//
 			// lblJoinPort
-			// 
+			//
 			this.lblJoinPort.Location = new System.Drawing.Point(4, 56);
 			this.lblJoinPort.Name = "lblJoinPort";
 			this.lblJoinPort.Size = new System.Drawing.Size(84, 20);
 			this.lblJoinPort.TabIndex = 6;
 			this.lblJoinPort.Text = "Port:";
 			this.lblJoinPort.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// lblJoinAddress
-			// 
+			//
 			this.lblJoinAddress.Location = new System.Drawing.Point(4, 28);
 			this.lblJoinAddress.Name = "lblJoinAddress";
 			this.lblJoinAddress.Size = new System.Drawing.Size(84, 20);
 			this.lblJoinAddress.TabIndex = 5;
 			this.lblJoinAddress.Text = "Address:";
 			this.lblJoinAddress.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
+			//
 			// btnCancel
-			// 
+			//
 			this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
 			this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -165,9 +164,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnCancel.Size = new System.Drawing.Size(104, 27);
 			this.btnCancel.TabIndex = 11;
 			this.btnCancel.Text = "Cancel";
-			// 
+			//
 			// btnJoin
-			// 
+			//
 			this.btnJoin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.btnJoin.DialogResult = System.Windows.Forms.DialogResult.OK;
 			this.btnJoin.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -178,9 +177,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			this.btnJoin.TabIndex = 10;
 			this.btnJoin.Text = "Join";
 			this.btnJoin.Click += new System.EventHandler(this.btnJoin_Click);
-			// 
+			//
 			// FormGameSpecify
-			// 
+			//
 			this.AcceptButton = this.btnJoin;
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.CancelButton = this.btnCancel;
@@ -203,7 +202,7 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		}
 		#endregion
-		
+
 		// Join clicked
 		private void btnJoin_Click(object sender, System.EventArgs e)
 		{

--- a/Source/Launcher/Interface/FormMain.cs
+++ b/Source/Launcher/Interface/FormMain.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Drawing;
 using System.IO;
@@ -20,7 +20,7 @@ namespace CodeImp.Bloodmasters.Launcher
     {
         private ServerBrowser browser;
         private bool updatelist = false;
-        private Hashtable flags = new Hashtable();
+        private Dictionary<string, int> flags = new();
 
         private System.Windows.Forms.PictureBox picLogo;
         private System.Windows.Forms.TabControl tabsMode;
@@ -1245,7 +1245,7 @@ namespace CodeImp.Bloodmasters.Launcher
             cmbMap.Items.Clear();
 
             // Go for all .wad files
-            ArrayList wads = ArchiveManager.FindAllFiles(".wad");
+            List<string> wads = ArchiveManager.FindAllFiles(".wad");
             foreach (string wf in wads)
             {
                 // Make short map name
@@ -1281,7 +1281,7 @@ namespace CodeImp.Bloodmasters.Launcher
             lstMaps.Items.Clear();
 
             // Go for all .wad files
-            ArrayList wads = ArchiveManager.FindAllFiles(".wad");
+            List<string> wads = ArchiveManager.FindAllFiles(".wad");
             foreach (string wf in wads)
             {
                 try
@@ -1391,15 +1391,15 @@ namespace CodeImp.Bloodmasters.Launcher
             string filename = (new string(countrycode)).ToLower() + ".ico";
 
             // Does this flag exist?
-            if (flags.Contains(filename))
+            if (flags.TryGetValue(filename, out int flag))
             {
                 // Return country flag
-                return (int)flags[filename];
+                return flag;
             }
             else
             {
                 // Return unknown flag
-                return (int)flags["_0.ico"];
+                return flags["_0.ico"];
                 //return 0;
             }
         }
@@ -1407,25 +1407,7 @@ namespace CodeImp.Bloodmasters.Launcher
         // This returns a flag icon image
         public Image GetFlagIcon(char[] countrycode)
         {
-            int index;
-
-            // Make the filename
-            string filename = (new string(countrycode)).ToLower() + ".ico";
-
-            // Does this flag exist?
-            if (flags.Contains(filename))
-            {
-                // Return country flag
-                index = (int)flags[filename];
-                return imglstFlags.Images[index];
-            }
-            else
-            {
-                // Return unknown flag
-                index = (int)flags["_0.ico"];
-                return imglstFlags.Images[index];
-                //return null;
-            }
+            return imglstFlags.Images[GetFlagIconIndex(countrycode)];
         }
 
         // This refreshes the list
@@ -1947,7 +1929,7 @@ namespace CodeImp.Bloodmasters.Launcher
                 lstGames.BeginUpdate();
 
                 // Get the whole list
-                Hashtable gitems = browser.GetFilteredList();
+                Dictionary<string, GamesListItem> gitems = browser.GetFilteredList();
 
                 // Go for all items to see if they need updating
                 for (int i = lstGames.Items.Count - 1; i >= 0; i--)
@@ -1956,11 +1938,8 @@ namespace CodeImp.Bloodmasters.Launcher
                     ListViewItem item = lstGames.Items[i];
 
                     // Item in the new collection?
-                    if (gitems.Contains(item.SubItems[9].Text))
+                    if (gitems.TryGetValue(item.SubItems[9].Text, out GamesListItem gi))
                     {
-                        // Get the server item
-                        GamesListItem gi = (GamesListItem)gitems[item.SubItems[9].Text];
-
                         // Update the item ifchanged
                         if (gi.Changed) gi.UpdateListViewItem(item);
 
@@ -1975,11 +1954,8 @@ namespace CodeImp.Bloodmasters.Launcher
                 }
 
                 // Go for all remaining items to add to the list
-                foreach (DictionaryEntry de in gitems)
+                foreach (GamesListItem gi in gitems.Values)
                 {
-                    // Get the server item
-                    GamesListItem gi = (GamesListItem)de.Value;
-
                     // Add to the list
                     gi.NewListViewItem(lstGames);
                 }

--- a/Source/Launcher/Interface/FormOptions.cs
+++ b/Source/Launcher/Interface/FormOptions.cs
@@ -5,8 +5,7 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using SharpDX.Direct3D9;
 
@@ -16,7 +15,7 @@ namespace CodeImp.Bloodmasters.Launcher
 	{
 		private int last_fsaa;
 		private DisplayMode last_mode;
-		private ListDictionary controlkeys = new ListDictionary();
+		private Dictionary<string, int> controlkeys = new();
 		private System.ComponentModel.Container components = null;
 		private System.Windows.Forms.Button btnOK;
 		private System.Windows.Forms.Button btnCancel;
@@ -119,7 +118,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				int keycode = General.config.ReadSetting("controls/" + c.Tag, (int)Keys.None);
 				if(c.SubItems.Count < 2) c.SubItems.Add("");
 				c.SubItems[1].Text = InputKey.GetKeyName(keycode);
-				controlkeys.Add(c.Tag, keycode);
+				controlkeys.Add((string)c.Tag, keycode);
 			}
 
 			// Other options in control
@@ -1138,23 +1137,23 @@ namespace CodeImp.Bloodmasters.Launcher
 				changed = false;
 
 				// Go for all in controlkeys
-				foreach(DictionaryEntry de in controlkeys)
+				foreach((string key, int value) in controlkeys)
 				{
 					// Not the same action?
-					if((string)de.Key != newaction)
+					if(key != newaction)
 					{
 						// Same control?
-						if((int)de.Value == control)
+						if(value == control)
 						{
 							// Set control to none
-							controlkeys[(string)de.Key] = (int)Keys.None;
+							controlkeys[key] = (int)Keys.None;
 
 							// This needs an update in the list
 							// so go for all items in the list
 							foreach(ListViewItem li in lstControls.Items)
 							{
 								// Check if this is the matching item
-								if((string)li.Tag == (string)de.Key)
+								if((string)li.Tag == key)
 								{
 									// Update the control displayed on this item
 									li.SubItems[1].Text = InputKey.GetKeyName((int)Keys.None);
@@ -1193,9 +1192,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			General.config.WriteSetting("teamcolorednames", chkTeamColoredNames.Checked);
 
 			// Apply controls
-			foreach(DictionaryEntry de in controlkeys)
+			foreach((string key, int value) in controlkeys)
 			{
-				General.config.WriteSetting("controls/" + de.Key, (int)de.Value);
+				General.config.WriteSetting("controls/" + key, value);
 			}
 
 			// Apply other options in controls
@@ -1307,7 +1306,7 @@ namespace CodeImp.Bloodmasters.Launcher
 				ListViewItem item = lstControls.SelectedItems[0];
 
 				// Get the key associated with the control
-				int keycode = (int)controlkeys[item.Tag];
+				int keycode = controlkeys[(string)item.Tag];
 
 				// Enable controls
 				lblAction.Enabled = true;
@@ -1354,17 +1353,19 @@ namespace CodeImp.Bloodmasters.Launcher
 				// Anything in combo selected?
 				if(cmbControl.SelectedItem != null)
 				{
+                    string itemTag = (string)item.Tag;
+
 					// Check if actually changing
-					if((int)controlkeys[item.Tag] != (int)cmbControl.SelectedItem)
+					if(controlkeys[itemTag] != (int)cmbControl.SelectedItem)
 					{
 						// Change the control
 						item.SubItems[1].Text = cmbControl.SelectedItem.ToString();
-						controlkeys[item.Tag] = (int)cmbControl.SelectedItem;
+						controlkeys[itemTag] = (int)cmbControl.SelectedItem;
 						cmbControl.SelectionLength = 0;
 						cmbControl.SelectionStart = cmbControl.Text.Length;
 
 						// Clear this control from any other actions
-						ClearExistingControl((string)item.Tag, (int)cmbControl.SelectedItem);
+						ClearExistingControl(itemTag, (int)cmbControl.SelectedItem);
 					}
 				}
 			}
@@ -1405,18 +1406,20 @@ namespace CodeImp.Bloodmasters.Launcher
 				// Get the selected item
 				ListViewItem item = lstControls.SelectedItems[0];
 
+                string itemTag = (string)item.Tag;
+
 				// Check if actually changing
-				if((int)controlkeys[item.Tag] != (int)e.KeyCode)
+				if(controlkeys[itemTag] != (int)e.KeyCode)
 				{
 					// Change the control
 					item.SubItems[1].Text = e.KeyCode.ToString();
-					controlkeys[item.Tag] = (int)e.KeyCode;
+					controlkeys[itemTag] = (int)e.KeyCode;
 					cmbControl.Text = e.KeyCode.ToString();
 					cmbControl.SelectionLength = 0;
 					cmbControl.SelectionStart = cmbControl.Text.Length;
 
 					// Clear this control from any other actions
-					ClearExistingControl((string)item.Tag, (int)e.KeyCode);
+					ClearExistingControl(itemTag, (int)e.KeyCode);
 				}
 			}
 

--- a/Source/Launcher/Interface/ServerBrowser.cs
+++ b/Source/Launcher/Interface/ServerBrowser.cs
@@ -6,7 +6,7 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -33,7 +33,7 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		// Networking
 		private Gateway gateway;
-		private ArrayList addresses = new ArrayList();
+		private List<IPEndPoint> addresses = new();
 		private int nextaddress;
 		private int nexttime;
 		private int queryinterval;
@@ -45,7 +45,7 @@ namespace CodeImp.Bloodmasters.Launcher
 										"http://server.codeimp.com/bloodmasterslist.php"};
 
 		// Servers
-		private Hashtable allitems = new Hashtable();
+		private Dictionary<string, GamesListItem> allitems = new();
 
 		#endregion
 
@@ -101,7 +101,7 @@ namespace CodeImp.Bloodmasters.Launcher
 		// Get an item by address
 		public GamesListItem GetItemByAddress(string addr)
 		{
-			return (GamesListItem)allitems[addr];
+			return allitems[addr];
 		}
 
 		// This tests if the given item passes the filter
@@ -139,21 +139,18 @@ namespace CodeImp.Bloodmasters.Launcher
 		}
 
 		// This returns a list of filtered servers
-		public Hashtable GetFilteredList()
+		public Dictionary<string, GamesListItem> GetFilteredList()
 		{
 			// Any items at all?
 			if(allitems != null)
 			{
 				// Make arraylist
-				Hashtable filtered = new Hashtable(allitems.Count);
+                Dictionary<string, GamesListItem> filtered = new Dictionary<string, GamesListItem>(allitems.Count);
 
 				// Go for all items
-				foreach(DictionaryEntry de in allitems)
+				foreach(GamesListItem item in allitems.Values)
 				{
-					// Get the item
-					GamesListItem item = (GamesListItem)de.Value;
-
-					// Not filtered out, then add to the list
+                    // Not filtered out, then add to the list
 					if((item != null) && (item.Address != null) && VisibleFilteredItem(item))
 						filtered.Add(item.Address.ToString(), item);
 				}
@@ -164,7 +161,7 @@ namespace CodeImp.Bloodmasters.Launcher
 			else
 			{
 				// No items
-				return new Hashtable();
+				return new Dictionary<string, GamesListItem>();
 			}
 		}
 
@@ -324,11 +321,10 @@ namespace CodeImp.Bloodmasters.Launcher
 					if(msg.Command == MsgCmd.ServerInfo)
 					{
 						// Already listed?
-						if(allitems.Contains(msg.Address.ToString()))
+						if(allitems.TryGetValue(msg.Address.ToString(), out item))
 						{
 							// Update this item
-							item = (GamesListItem)allitems[msg.Address.ToString()];
-							item.Update(msg);
+                            item.Update(msg);
 						}
 						else
 						{
@@ -356,7 +352,7 @@ namespace CodeImp.Bloodmasters.Launcher
 					try
 					{
 						// Get the address
-						addr = (IPEndPoint)addresses[nextaddress];
+						addr = addresses[nextaddress];
 
 						// Send query message
 						QueryServer(addr);

--- a/Source/Server/General/Client.cs
+++ b/Source/Server/General/Client.cs
@@ -5,8 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-
 namespace CodeImp.Bloodmasters.Server
 {
 	public class Client : IPhysicsState
@@ -829,7 +827,7 @@ namespace CodeImp.Bloodmasters.Server
 		// Returns false when no spawn spots found
 		public bool TeleportToThing(int tag, Vector3D oldpos)
 		{
-			ArrayList dests = new ArrayList(10);
+			List<Thing> dests = new List<Thing>(10);
 
 			// Go for all things on the map
 			foreach(Thing t in Host.Instance.Server.map.Things)
@@ -851,7 +849,7 @@ namespace CodeImp.Bloodmasters.Server
 			else
 			{
 				// Choose a random destination
-				Thing ft = (Thing)dests[Host.Instance.Random.Next(dests.Count)];
+				Thing ft = dests[Host.Instance.Random.Next(dests.Count)];
 
 				// Go for all other clients
 				foreach(Client c in Host.Instance.Server.clients)
@@ -1898,12 +1896,9 @@ namespace CodeImp.Bloodmasters.Server
 		public void SendAllItemPickups()
 		{
 			// Go for all items
-			foreach(DictionaryEntry de in Host.Instance.Server.items)
+			foreach(Item i in Host.Instance.Server.items.Values)
 			{
-				// Get the item
-				Item i = (Item)de.Value;
-
-				// Send pickup message if taken
+                // Send pickup message if taken
 				if(i.IsTaken || i.IsAttached)
 					SendItemPickup(i.Owner, i, i.IsAttached, true);
 			}
@@ -2504,12 +2499,9 @@ namespace CodeImp.Bloodmasters.Server
 			if(state != null)
 			{
 				// Go for all items
-				foreach(DictionaryEntry de in Host.Instance.Server.items)
+				foreach(Item i in Host.Instance.Server.items.Values)
 				{
-					// Get the item
-					Item i = (Item)de.Value;
-
-					// Item not taken or attached?
+                    // Item not taken or attached?
 					if(!i.IsTaken && !i.IsAttached)
 					{
 						// Check if within acceptable Z level
@@ -2542,7 +2534,7 @@ namespace CodeImp.Bloodmasters.Server
 		private void PerformZChanges()
 		{
 			float highestz = float.MinValue;
-			ArrayList sectors;
+            List<Sector> sectors;
 
 			// Find touching sectors
 			sectors = Host.Instance.Server.map.FindTouchingSectors(state.pos.x, state.pos.y, Consts.PLAYER_RADIUS);

--- a/Source/Server/General/GameServer.cs
+++ b/Source/Server/General/GameServer.cs
@@ -56,7 +56,7 @@ namespace CodeImp.Bloodmasters.Server
 		private bool joinsmallest;
 		private int port;
 		private bool makepublic;
-		private ArrayList mapnames;
+		private List<string> mapnames;
 		private string rconpassword;
 		private bool isteamgame;
 		private bool jointeamspectating;
@@ -70,15 +70,15 @@ namespace CodeImp.Bloodmasters.Server
 		public Bloodmasters.Map map;
 
 		// Items
-		public Hashtable items;
+		public Dictionary<string, Item> items;
 
 		// Projectiles
-		public Hashtable projectiles;
-		public ArrayList disposeprojectiles;
+		public Dictionary<string, Projectile> projectiles;
+		public List<Projectile> disposeprojectiles;
 		public int nextprojectileid;
 
 		// Dynamic sectors for processing
-		public ArrayList dynamics;
+		public List<DynamicSector> dynamics;
 
 		// Networking
 		public Gateway gateway;
@@ -86,7 +86,7 @@ namespace CodeImp.Bloodmasters.Server
 
 		// All clients
 		public Client[] clients;
-		public Hashtable clientsaddrs;
+		public Dictionary<string, Client> clientsaddrs;
 		private int numclients;
 
 		// Team scores
@@ -94,8 +94,8 @@ namespace CodeImp.Bloodmasters.Server
 
 		// Bans
 		private string localbansfile;
-		private ArrayList localbans;
-		private ArrayList globalbans;
+		private List<string> localbans;
+		private List<string> globalbans;
 
 		// Callvote
 		public int callvotetimeout;
@@ -168,7 +168,7 @@ namespace CodeImp.Bloodmasters.Server
 
 			// Make the maps list
 			IDictionary maps = cfg.ReadSetting("maps", new ListDictionary());
-			mapnames = new ArrayList(maps.Count);
+			mapnames = new List<string>(maps.Count);
 			foreach(DictionaryEntry de in maps) mapnames.Add(de.Key.ToString());
 
 			// Fix possible input errors
@@ -190,7 +190,7 @@ namespace CodeImp.Bloodmasters.Server
 
 			// Initialize clients array
 			clients = new Client[maxclients];
-			clientsaddrs = new Hashtable(maxclients);
+			clientsaddrs = new Dictionary<string, Client>(maxclients);
 
 			// Start the gateway
 			gateway = new ServerGateway(port, 0, 0);
@@ -239,7 +239,7 @@ namespace CodeImp.Bloodmasters.Server
 			}
 
 			// Start with the first map
-			StartCurrentMap(mapnames[currentmap].ToString());
+			StartCurrentMap(mapnames[currentmap]);
 		}
 
 		// This terminates the server
@@ -263,22 +263,14 @@ namespace CodeImp.Bloodmasters.Server
 			// Dispose all items
 			if(items != null)
 			{
-				ICollection itemscol = items.Values;
-				ArrayList itemsarray = new ArrayList(itemscol);
-				foreach(Item i in itemsarray) i.Dispose();
-				itemsarray = null;
-				itemscol = null;
-			}
+                foreach(Item i in items.Values) i.Dispose();
+            }
 
 			// Dispose projectiles
 			if(projectiles != null)
 			{
-				ICollection prjcol = projectiles.Values;
-				ArrayList prjarray = new ArrayList(prjcol);
-				foreach(Projectile p in prjarray) p.Dispose();
-				prjarray = null;
-				prjcol = null;
-			}
+                foreach(Projectile p in projectiles.Values) p.Dispose();
+            }
 
 			// Clean up
 			if(gateway != null) gateway.Dispose();
@@ -367,7 +359,7 @@ namespace CodeImp.Bloodmasters.Server
 			string line;
 
 			// Read all lines
-			globalbans = new ArrayList();
+			globalbans = new List<string>();
 			while((line = readbody.ReadLine()) != null)
 			{
 				// Anything on this line?
@@ -385,7 +377,7 @@ namespace CodeImp.Bloodmasters.Server
 			string line;
 
 			// Read all lines
-			localbans = new ArrayList();
+			localbans = new List<string>();
 			while((line = readbody.ReadLine()) != null)
 			{
 				// Comment // on the line?
@@ -580,7 +572,7 @@ namespace CodeImp.Bloodmasters.Server
 		{
 			// Move to next map in list or restart list
 			if(currentmap >= mapnames.Count - 1) currentmap = 0; else currentmap++;
-			StartCurrentMap(mapnames[currentmap].ToString());
+			StartCurrentMap(mapnames[currentmap]);
 		}
 
 		// This loads the map with the current settings
@@ -589,7 +581,7 @@ namespace CodeImp.Bloodmasters.Server
 			int thinggametype = (int)Math.Pow(2, (int)Host.Instance.Server.GameType);
 
 			// Name of the next map
-			//string nextmapname = mapnames[currentmap].ToString();
+			//string nextmapname = mapnames[currentmap];
 			Write("Server is loading map \"" + nextmapname + "\"...", true);
 
 			// Load the map title
@@ -620,11 +612,11 @@ namespace CodeImp.Bloodmasters.Server
 			map = new ServerMap(nextmapname, false, Host.Instance.TempPath);
 
 			// New items
-			items = new Hashtable();
+			items = new Dictionary<string, Item>();
 
 			// New projectiles
-			projectiles = new Hashtable();
-			disposeprojectiles = new ArrayList();
+			projectiles = new Dictionary<string, Projectile>();
+			disposeprojectiles = new List<Projectile>();
 			nextprojectileid = 0;
 
 			// Ensure unique item ids start at 0
@@ -660,7 +652,7 @@ namespace CodeImp.Bloodmasters.Server
 									object[] args = new object[1];
 									args[0] = t;
 									Item item = (Item)asm.CreateInstance(tp.FullName, false, BindingFlags.Default,
-														null, args, CultureInfo.CurrentCulture, new object[0]);
+														null, args, CultureInfo.CurrentCulture, Array.Empty<object>());
 
 									// If the item is not temporary
 									// then add it to the items list
@@ -673,7 +665,7 @@ namespace CodeImp.Bloodmasters.Server
 			}
 
 			// Make dynamic sectors
-			dynamics = new ArrayList();
+			dynamics = new List<DynamicSector>();
 			foreach(Sector s in map.Sectors)
 			{
 				// Presume no dynamic item
@@ -858,7 +850,7 @@ namespace CodeImp.Bloodmasters.Server
 
 			// Move to next map in list or restart list
 			if(currentmap >= mapnames.Count - 1) currentmap = 0; else currentmap++;
-			StartCurrentMap(mapnames[currentmap].ToString());
+			StartCurrentMap(mapnames[currentmap]);
 
 			// New gamestate
 			DM_ToWaiting();
@@ -948,7 +940,7 @@ namespace CodeImp.Bloodmasters.Server
 
 			// Move to next map in list or restart list
 			if(currentmap >= mapnames.Count - 1) currentmap = 0; else currentmap++;
-			StartCurrentMap(mapnames[currentmap].ToString());
+			StartCurrentMap(mapnames[currentmap]);
 
 			// New gamestate
 			CTF_ToWaiting();
@@ -1038,7 +1030,7 @@ namespace CodeImp.Bloodmasters.Server
 
 			// Move to next map in list or restart list
 			if(currentmap >= mapnames.Count - 1) currentmap = 0; else currentmap++;
-			StartCurrentMap(mapnames[currentmap].ToString());
+			StartCurrentMap(mapnames[currentmap]);
 
 			// New gamestate
 			SC_ToWaiting();
@@ -1416,12 +1408,9 @@ namespace CodeImp.Bloodmasters.Server
 					else
 					{
 						// Client with this connection?
-						if(clientsaddrs.Contains(msg.Address.ToString()))
+						if(clientsaddrs.TryGetValue(msg.Address.ToString(), out clnt))
 						{
-							// Get the client
-							clnt = (Client)clientsaddrs[msg.Address.ToString()];
-
-							// Handle message command
+                            // Handle message command
 							switch(msg.Command)
 							{
 								case MsgCmd.Disconnect: clnt.hDisconnect(msg); break;
@@ -1639,7 +1628,7 @@ namespace CodeImp.Bloodmasters.Server
 			if(connectid == msg.Connection.RandomID)
 			{
 				// Not already logged in?
-				if(!clientsaddrs.Contains(msg.Connection.Address.ToString()))
+				if(!clientsaddrs.ContainsKey(msg.Connection.Address.ToString()))
 				{
 					// Check the password
 					if((givenpassword == password) || (password.Trim() == ""))
@@ -2442,7 +2431,7 @@ namespace CodeImp.Bloodmasters.Server
 		public void RespawnAllItems()
 		{
 			// Respawn all items
-			foreach(DictionaryEntry de in items) ((Item)de.Value).Respawn();
+			foreach(Item item in items.Values) item.Respawn();
 		}
 
 		#endregion
@@ -2463,7 +2452,7 @@ namespace CodeImp.Bloodmasters.Server
 			}
 
 			// Process all projectiles
-			ArrayList prjs = new ArrayList(projectiles.Values);
+			List<Projectile> prjs = new List<Projectile>(projectiles.Values);
 			foreach(Projectile p in prjs)
 			{
 				// Process the projectile
@@ -2482,7 +2471,7 @@ namespace CodeImp.Bloodmasters.Server
 			BroadcastSectorMovements();
 
 			// Process all items
-			foreach(DictionaryEntry de in items) ((Item)de.Value).Process();
+			foreach(Item item in items.Values) item.Process();
 
 			// Process all clients
 			for(int i = 0; i < maxclients; i++)

--- a/Source/Server/Items/ScavengerItem.cs
+++ b/Source/Server/Items/ScavengerItem.cs
@@ -5,8 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-
 namespace CodeImp.Bloodmasters.Server
 {
 	public class ScavengerItem : Item
@@ -47,21 +45,14 @@ namespace CodeImp.Bloodmasters.Server
 			int result = 0;
 
 			// Go for all items in the map
-			foreach(DictionaryEntry de in Host.Instance.Server.items)
+            foreach(ScavengerItem si in Host.Instance.Server.items.Values.OfType<ScavengerItem>())
 			{
-				// Is this a scavenger item?
-				if(de.Value is ScavengerItem)
-				{
-					// Get the object
-					ScavengerItem si = (ScavengerItem)de.Value;
-
-					// Item for this team?
-					if(si.ThisTeam == team)
-					{
-						// Count when item is not taken yet
-						if(si.IsTaken == false) result++;
-					}
-				}
+                // Item for this team?
+                if(si.ThisTeam == team)
+                {
+                    // Count when item is not taken yet
+                    if(si.IsTaken == false) result++;
+                }
 			}
 
 			// Return result
@@ -72,21 +63,14 @@ namespace CodeImp.Bloodmasters.Server
 		public static void RespawnItems(TEAM team)
 		{
 			// Go for all items in the map
-			foreach(DictionaryEntry de in Host.Instance.Server.items)
+			foreach(ScavengerItem si in Host.Instance.Server.items.Values.OfType<ScavengerItem>())
 			{
-				// Is this a scavenger item?
-				if(de.Value is ScavengerItem)
-				{
-					// Get the object
-					ScavengerItem si = (ScavengerItem)de.Value;
-
-					// Item for this team?
-					if(si.ThisTeam == team)
-					{
-						// Set the respawn time to respawn immediately
-						si.RespawnDelay = 1;
-					}
-				}
+                // Item for this team?
+                if(si.ThisTeam == team)
+                {
+                    // Set the respawn time to respawn immediately
+                    si.RespawnDelay = 1;
+                }
 			}
 		}
 

--- a/Source/Server/Projectiles/Projectile.cs
+++ b/Source/Server/Projectiles/Projectile.cs
@@ -5,8 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-
 namespace CodeImp.Bloodmasters.Server
 {
 	public abstract class Projectile
@@ -125,7 +123,7 @@ namespace CodeImp.Bloodmasters.Server
 		// This teleports the projectile
 		private void TeleportToThing(int tag)
 		{
-			ArrayList dests = new ArrayList(10);
+			List<Thing> dests = new List<Thing>(10);
 			float zdiff;
 
 			// Keep old position
@@ -146,7 +144,7 @@ namespace CodeImp.Bloodmasters.Server
 			if(dests.Count > 0)
 			{
 				// Choose a random destination
-				Thing ft = (Thing)dests[Host.Instance.Random.Next(dests.Count)];
+				Thing ft = dests[Host.Instance.Random.Next(dests.Count)];
 
 				// Determine floor height difference
 				zdiff = state.pos.z - sector.CurrentFloor;

--- a/Source/Shared/Archive.cs
+++ b/Source/Shared/Archive.cs
@@ -8,7 +8,6 @@
 // This class provides functionality to read files from an
 // archive (Directory or RAR file).
 
-using System.Collections;
 using System.Runtime.InteropServices;
 
 namespace CodeImp
@@ -193,8 +192,8 @@ namespace CodeImp
 		private void Open(string pathname)
 		{
 			int result;
-			ArrayList files = new ArrayList();
-			ArrayList crcs = new ArrayList();
+			List<string> files = new List<string>();
+			List<uint> crcs = new List<uint>();
 
 			// Set the archive pathname and title
 			archivename = pathname;
@@ -263,8 +262,8 @@ namespace CodeImp
 				}
 
 				// Make standard array from files
-				archivefiles = (string[])files.ToArray(typeof(string));
-				archivefilecrcs = (uint[])crcs.ToArray(typeof(uint));
+				archivefiles = files.ToArray();
+				archivefilecrcs = crcs.ToArray();
 
 				// Close archive
 				RARCloseArchive(archive);

--- a/Source/Shared/ArchiveManager.cs
+++ b/Source/Shared/ArchiveManager.cs
@@ -5,8 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
-
 namespace CodeImp.Bloodmasters
 {
 	public class ArchiveManager
@@ -14,7 +12,7 @@ namespace CodeImp.Bloodmasters
 		#region ================== Variables
 
 		// All archives
-		private static Hashtable archives = new Hashtable();
+		private static Dictionary<string, Archive> archives = new();
 
 		// Temporary path
 		private static string temppath;
@@ -30,18 +28,14 @@ namespace CodeImp.Bloodmasters
 		}
 
 		// This finds all files of a specific type in all archives
-		public static ArrayList FindAllFiles(string filetype)
+		public static List<string> FindAllFiles(string filetype)
 		{
-			ArrayList result = new ArrayList();
+			List<string> result = new List<string>();
 
 			// Go for all archives
-			foreach(DictionaryEntry de in archives)
+			foreach((string archivename, Archive a) in archives)
 			{
-				// Get filename and archive
-				string archivename = (string)de.Key;
-				Archive a = (Archive)de.Value;
-
-				// Go for all files in archive
+                // Go for all files in archive
 				foreach(string f in a.FileNames)
 				{
 					// Filename matches?
@@ -61,13 +55,9 @@ namespace CodeImp.Bloodmasters
 		public static string FindFileArchive(string filename)
 		{
 			// Go for all archives
-			foreach(DictionaryEntry de in archives)
+			foreach((string archivename, Archive a) in archives)
 			{
-				// Get filename and archive
-				string archivename = (string)de.Key;
-				Archive a = (Archive)de.Value;
-
-				// File in this archive?
+                // File in this archive?
 				if(a.FileExists(filename))
 				{
 					// Return the name of this archive
@@ -83,10 +73,10 @@ namespace CodeImp.Bloodmasters
 		public static Archive GetArchive(string archivename)
 		{
 			// Check if archive exists
-			if(archives.Contains(archivename))
+			if(archives.TryGetValue(archivename, out Archive archive))
 			{
 				// Return archive
-				return (Archive)archives[archivename];
+				return archive;
 			}
 			else
 			{
@@ -106,10 +96,10 @@ namespace CodeImp.Bloodmasters
 			string archivename = files[0].ToLower();
 
 			// Check if archive exists
-			if(archives.Contains(archivename))
+			if(archives.TryGetValue(archivename, out Archive archive))
 			{
 				// Return archive
-				return (Archive)archives[archivename];
+				return archive;
 			}
 			else
 			{
@@ -128,10 +118,9 @@ namespace CodeImp.Bloodmasters
 			string archivename = files[0].ToLower();
 
 			// Check if archive exists
-			if(archives.Contains(archivename))
+			if(archives.TryGetValue(archivename, out Archive a))
 			{
 				// Check if archive has the specified file
-				Archive a = (Archive)archives[archivename];
 				return a.FileExists(files[1]);
 			}
 			else
@@ -213,13 +202,9 @@ namespace CodeImp.Bloodmasters
 		public static void Dispose()
 		{
 			// Close all archives
-			foreach(DictionaryEntry de in archives)
+			foreach((string filename, Archive a) in archives)
 			{
-				// Get filename and archive
-				string filename = (string)de.Key;
-				Archive a = (Archive)de.Value;
-
-				// Close archive
+                // Close archive
 				a.Dispose();
 
 				// Remove temporary directory

--- a/Source/Shared/IPhysicsState.cs
+++ b/Source/Shared/IPhysicsState.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters

--- a/Source/Shared/Line2D.cs
+++ b/Source/Shared/Line2D.cs
@@ -7,93 +7,92 @@
 
 using System;
 using System.Drawing;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters
 {
 	public struct Line2D
-	{	
+	{
 		#region ================== Members
-		
+
 		// Members
 		public Vector2D v1;
 		public Vector2D v2;
-		
+
 		#endregion
-		
+
 		#region ================== Properties
-		
+
 		// Properties
 		public Vector2D d { get { return v2 - v1; } }
 		public float dx { get { return v2.x - v1.x; } }
 		public float dy { get { return v2.y - v1.y; } }
-		
+
 		#endregion
-		
+
 		#region ================== Constructors
-		
+
 		// Constructor
 		public Line2D(Vector2D v1, Vector2D v2)
 		{
 			this.v1 = v1;
 			this.v2 = v2;
 		}
-		
+
 		// Constructor
 		public Line2D(Vector2D v1, float dx, float dy)
 		{
 			this.v1 = v1;
 			this.v2 = new Vector2D(v1.x + dx, v1.y + dy);
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Static Methods
-		
+
 		// This calculates the length
 		public static float Length(float dx, float dy)
 		{
 			// Calculate and return the length
 			return (float)Math.Sqrt(LengthSq(dx, dy));
 		}
-		
+
 		// This calculates the square of the length
 		public static float LengthSq(float dx, float dy)
 		{
 			// Calculate and return the length
 			return dx * dx + dy * dy;
 		}
-		
+
 		// This tests if the line intersects with the given line coordinates
 		public static bool IntersectLine(Vector2D v1, Vector2D v2, float x3, float y3, float x4, float y4)
 		{
 			float u_ray, u_line;
 			return IntersectLine(v1, v2, x3, y3, x4, y4, out u_ray, out u_line);
 		}
-		
+
 		// This tests if the line intersects with the given line coordinates
 		public static bool IntersectLine(Vector2D v1, Vector2D v2, float x3, float y3, float x4, float y4, out float u_ray)
 		{
 			float u_line;
 			return IntersectLine(v1, v2, x3, y3, x4, y4, out u_ray, out u_line);
 		}
-		
+
 		// This tests if the line intersects with the given line coordinates
 		public static bool IntersectLine(Vector2D v1, Vector2D v2, float x3, float y3, float x4, float y4, out float u_ray, out float u_line)
 		{
 			// Calculate divider
 			float div = (y4 - y3) * (v2.x - v1.x) - (x4 - x3) * (v2.y - v1.y);
-			
+
 			// Can this be tested?
 			if((div > 0.000001f) || (div < -0.000001f))
 			{
 				// Calculate the intersection distance from the line
 				u_line = ((x4 - x3) * (v1.y - y3) - (y4 - y3) * (v1.x - x3)) / div;
-				
+
 				// Calculate the intersection distance from the ray
 				u_ray = ((v2.x - v1.x) * (v1.y - y3) - (v2.y - v1.y) * (v1.x - x3)) / div;
-				
+
 				// Return if intersecting
 				return (u_ray >= 0.0f) && (u_ray <= 1.0f) && (u_line >= 0.0f) && (u_line <= 1.0f);
 			}
@@ -105,7 +104,7 @@ namespace CodeImp.Bloodmasters
 				return false;
 			}
 		}
-		
+
 		// This tests on which side of the line the given coordinates are
 		// returns < 0 for front (right) side, > 0 for back (left) side and 0 if on the line
 		public static float SideOfLine(Vector2D v1, Vector2D v2, Vector2D p)
@@ -113,19 +112,19 @@ namespace CodeImp.Bloodmasters
 			// Calculate and return side information
 			return (p.y - v1.y) * (v2.x - v1.x) - (p.x - v1.x) * (v2.y - v1.y);
 		}
-		
+
 		// This returns the shortest distance from given coordinates to line
 		public static float DistanceToLine(Vector2D v1, Vector2D v2, Vector2D p, bool bounded)
 		{
 			return (float)Math.Sqrt(DistanceToLineSq(v1, v2, p, bounded));
 		}
-		
+
 		// This returns the shortest distance from given coordinates to line
 		public static float DistanceToLineSq(Vector2D v1, Vector2D v2, Vector2D p, bool bounded)
 		{
 			// Calculate intersection offset
 			float u = ((p.x - v1.x) * (v2.x - v1.x) + (p.y - v1.y) * (v2.y - v1.y)) / LengthSq(v2.x - v1.x, v2.y - v1.y);
-			
+
 			if(bounded)
 			{
 				// Limit intersection offset to the line
@@ -134,78 +133,78 @@ namespace CodeImp.Bloodmasters
 				if(u < lbound) u = lbound;
 				if(u > ubound) u = ubound;
 			}
-			
+
 			// Calculate intersection point
 			Vector2D i = v1 + u * (v2 - v1);
-			
+
 			// Return distance between intersection and point
 			// which is the shortest distance to the line
 			float ldx = p.x - i.x;
 			float ldy = p.y - i.y;
 			return ldx * ldx + ldy * ldy;
 		}
-		
+
 		// This returns the offset coordinates on the line nearest to the given coordinates
 		public static float NearestOnLine(Vector2D v1, Vector2D v2, Vector2D p)
 		{
 			// Calculate and return intersection offset
 			return ((p.x - v1.x) * (v2.x - v1.x) + (p.y - v1.y) * (v2.y - v1.y)) / LengthSq(v2.x - v1.x, v2.y - v1.y);
 		}
-		
+
 		// This returns the coordinates at a specific position on the line
 		public static Vector2D CoordinatesAt(Vector2D v1, Vector2D v2, float u)
 		{
 			// Calculate and return intersection offset
 			return new Vector2D(v1.x + u * (v2.x - v1.x), v1.y + u * (v2.y - v1.y));
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Methods
-		
+
 		public float Length() { return Line2D.Length(dx, dy); }
 		public float LengthSq() { return Line2D.LengthSq(dx, dy); }
-		
+
 		public bool IntersectLine(float x3, float y3, float x4, float y4)
 		{
 			return Line2D.IntersectLine(v1, v2, x3, y3, x4, y4);
 		}
-		
+
 		public bool IntersectLine(float x3, float y3, float x4, float y4, out float u_ray)
 		{
 			return Line2D.IntersectLine(v1, v2, x3, y3, x4, y4, out u_ray);
 		}
-		
+
 		public bool IntersectLine(float x3, float y3, float x4, float y4, out float u_ray, out float u_line)
 		{
 			return Line2D.IntersectLine(v1, v2, x3, y3, x4, y4, out u_ray, out u_line);
 		}
-		
+
 		public float SideOfLine(Vector2D p)
 		{
 			return Line2D.SideOfLine(v1, v2, p);
 		}
-		
+
 		public float DistanceToLine(Vector2D p, bool bounded)
 		{
 			return Line2D.DistanceToLine(v1, v2, p, bounded);
 		}
-		
+
 		public float DistanceToLineSq(Vector2D p, bool bounded)
 		{
 			return Line2D.DistanceToLineSq(v1, v2, p, bounded);
 		}
-		
+
 		public float NearestOnLine(Vector2D p)
 		{
 			return Line2D.NearestOnLine(v1, v2, p);
 		}
-		
+
 		public Vector2D CoordinatesAt(float u)
 		{
 			return Line2D.CoordinatesAt(v1, v2, u);
 		}
-		
+
 		#endregion
 	}
 }

--- a/Source/Shared/Map/BlockMap.cs
+++ b/Source/Shared/Map/BlockMap.cs
@@ -6,7 +6,6 @@
 \********************************************************************/
 
 using System;
-using System.Collections;
 using System.Drawing;
 using System.IO;
 
@@ -27,7 +26,7 @@ namespace CodeImp.Bloodmasters
 		private Map map;
 
 		// Blockmap
-		private ArrayList[,] blocks;
+		private List<Linedef>[,] blocks;
 		private int cols;
 		private int rows;
 		private float ox;
@@ -60,9 +59,9 @@ namespace CodeImp.Bloodmasters
 			cols = data.ReadUInt16();
 			rows = data.ReadUInt16();
 
-			// Make blockmap array and an
+			// Make blockmap list and an
 			// array to keep the offsets
-			blocks = new ArrayList[cols, rows];
+			blocks = new List<Linedef>[cols, rows];
 			int[,] offsets = new int[cols, rows];
 
 			// Go for all rows and columns
@@ -83,7 +82,7 @@ namespace CodeImp.Bloodmasters
 				for(int c = 0; c < cols; c++)
 				{
 					// Make a list for the linedefs
-					blocks[c, r] = new ArrayList();
+					blocks[c, r] = new List<Linedef>();
 
 					// Seek to the offset for this block
 					data.BaseStream.Seek(offsets[c, r], SeekOrigin.Begin);
@@ -117,7 +116,7 @@ namespace CodeImp.Bloodmasters
 		#region ================== Methods
 
 		// This returns the nearby lines for a specific line
-		public ArrayList GetCollisionLines(float x1, float y1, float x2, float y2)
+		public List<Linedef> GetCollisionLines(float x1, float y1, float x2, float y2)
 		{
 			bool[] lineadded = new bool[map.Linedefs.Length];
 			Vector2D v1, v2;
@@ -128,7 +127,7 @@ namespace CodeImp.Bloodmasters
 			int dirx, diry;
 
 			// Make list for the lines
-			ArrayList lines = new ArrayList(EXPECTED_LINES_PER_TEST);
+            List<Linedef> lines = new List<Linedef>(EXPECTED_LINES_PER_TEST);
 
 			// Adjust coordinates to match blockmap offset
 			v1 = new Vector2D(x1 - ox, y1 - oy);
@@ -216,7 +215,7 @@ namespace CodeImp.Bloodmasters
 
 		// This returns the nearby lines for a specific line and radius
 		// NOTE: Line and radius are used to find the lines in a square region
-		public ArrayList GetCollisionLines(float x1, float y1, float x2, float y2, float radius)
+		public List<Linedef> GetCollisionLines(float x1, float y1, float x2, float y2, float radius)
 		{
 			float l, r, b, t;
 
@@ -235,14 +234,14 @@ namespace CodeImp.Bloodmasters
 		}
 
 		// This returns the nearby lines for a specific position and radius
-		public ArrayList GetCollisionLines(float x, float y, float radius)
+		public List<Linedef> GetCollisionLines(float x, float y, float radius)
 		{
 			// Make region and return lines in region
 			return GetCollisionLines(new RectangleF(x - radius, y - radius, radius * 2, radius * 2));
 		}
 
 		// This returns the lines for a specific region
-		public ArrayList GetCollisionLines(RectangleF region)
+		public List<Linedef> GetCollisionLines(RectangleF region)
 		{
 			bool[] lineadded = new bool[map.Linedefs.Length];
 			int c1, c2, r1, r2, c, r;
@@ -261,7 +260,7 @@ namespace CodeImp.Bloodmasters
 			if(r2 < 0) r2 = 0; else if(r2 >= rows) r2 = rows - 1;
 
 			// Make list for the lines
-			ArrayList lines = new ArrayList(EXPECTED_LINES_PER_TEST);
+            List<Linedef> lines = new List<Linedef>(EXPECTED_LINES_PER_TEST);
 
 			// Add lines to the list
 			for(c = c1; c <= c2; c++)
@@ -273,7 +272,7 @@ namespace CodeImp.Bloodmasters
 		}
 
 		// This adds lines from a block to a list
-		private void AddBlockLines(ArrayList lines, int r, int c, ref bool[] lineadded)
+		private void AddBlockLines(List<Linedef> lines, int r, int c, ref bool[] lineadded)
 		{
 			// Go for all lines
 			foreach(Linedef ld in blocks[c, r])

--- a/Source/Shared/Map/Map.cs
+++ b/Source/Shared/Map/Map.cs
@@ -5,7 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -629,12 +628,12 @@ namespace CodeImp.Bloodmasters
 
 		// This finds all "touching sectors"
 		// these are the sectors an object is overlapping
-		public ArrayList FindTouchingSectors(float x, float y, float radius)
+		public List<Sector> FindTouchingSectors(float x, float y, float radius)
 		{
-			ArrayList sectors = new ArrayList();
+            List<Sector> sectors = new  List<Sector>();
 
 			// Get all the nearby lines to check for intersection
-			ArrayList lines = blockmap.GetCollisionLines(x, y, radius);
+            List<Linedef> lines = blockmap.GetCollisionLines(x, y, radius);
 
 			// Go for all lines
 			foreach(Linedef ld in lines)
@@ -710,7 +709,7 @@ namespace CodeImp.Bloodmasters
 		}
 
 		// This returns the linedef nearest to the given coordinates
-		public Linedef GetNearestLine(float x, float y, IEnumerable linedefs)
+		public Linedef GetNearestLine(float x, float y, IEnumerable<Linedef> linedefs)
 		{
 			Linedef foundline = null;
 			float founddist = float.MaxValue;
@@ -757,7 +756,7 @@ namespace CodeImp.Bloodmasters
 			bool[] sectortested = new bool[sectors.Length];
 
 			// Find all lines near the trajectory
-			ArrayList lines = blockmap.GetCollisionLines(start.x, start.y, end.x, end.y);
+            List<Linedef> lines = blockmap.GetCollisionLines(start.x, start.y, end.x, end.y);
 
 			// No lines?
 			if(lines.Count == 0)

--- a/Source/Shared/Map/RejectMap.cs
+++ b/Source/Shared/Map/RejectMap.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.IO;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters
@@ -15,23 +14,23 @@ namespace CodeImp.Bloodmasters
 	public class RejectMap
 	{
 		#region ================== Variables
-		
+
 		// Reject table
 		private bool[,] reject;
-		
+
 		#endregion
-		
+
 		#region ================== Constructor / Destructor
-		
+
 		// Constructor
 		public RejectMap(BinaryReader data, int numsectors)
 		{
 			int dbit = 8;
 			byte dbyte = 0;
-			
+
 			// Make reject array
 			reject = new bool[numsectors, numsectors];
-			
+
 			// Go through the entire reject table
 			for(int t = 0; t < numsectors; t++)
 			{
@@ -44,44 +43,44 @@ namespace CodeImp.Bloodmasters
 						dbyte = data.ReadByte();
 						dbit = 0;
 					}
-					
+
 					// Fill the reject entry
 					reject[s, t] = (dbyte & (1 << dbit)) > 0;
-					
+
 					// Next bit
 					dbit++;
 				}
 			}
-			
+
 			// Clean up
 			data.Close();
 		}
-		
+
 		// Destructor
 		public void Dispose()
 		{
 			// Clean up
 			reject = null;
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Methods
-		
+
 		// This consults the reject map for possible visibility
 		public bool CanBeVisible(int sector1, int sector2)
 		{
 			// Return the reject result
 			return (reject[sector1, sector2] == false);
 		}
-		
+
 		// This consults the reject map for invisibility
 		public bool IsInvisible(int sector1, int sector2)
 		{
 			// Return the reject result
 			return reject[sector1, sector2];
 		}
-		
+
 		#endregion
 	}
 }

--- a/Source/Shared/Map/Sector.cs
+++ b/Source/Shared/Map/Sector.cs
@@ -5,7 +5,6 @@
 *                                                                   *
 \********************************************************************/
 
-using System.Collections;
 using System.Drawing;
 
 namespace CodeImp.Bloodmasters
@@ -66,7 +65,7 @@ namespace CodeImp.Bloodmasters
 		protected Sector[] adjsectors;
 
 		// Items
-		private ArrayList items = new ArrayList();
+		private List<object> items = new();
 
 		#endregion
 
@@ -125,7 +124,7 @@ namespace CodeImp.Bloodmasters
 		public Sector[] AdjacentSectors { get { return adjsectors; } }
 
 		// Items
-		public ArrayList Items { get { return items; } }
+		public List<object> Items { get { return items; } }
 
 		#endregion
 
@@ -254,7 +253,7 @@ namespace CodeImp.Bloodmasters
 		// This finds all adjacent sectors
 		public void FindAdjacentSectors()
 		{
-			ArrayList adjs = new ArrayList();
+			List<Sector> adjs = new List<Sector>();
 
 			// Go for all subsectors
 			foreach(SubSector ss in subsectors)
@@ -275,7 +274,7 @@ namespace CodeImp.Bloodmasters
 			}
 
 			// Make the array
-			adjsectors = (Sector[])adjs.ToArray(typeof(Sector));
+			adjsectors = adjs.ToArray();
 		}
 
 		// This finds the lowest adjacent floor

--- a/Source/Shared/Net/Connection.cs
+++ b/Source/Shared/Net/Connection.cs
@@ -25,7 +25,6 @@ The Connection
 
 */
 
-using System.Collections;
 using System.Net;
 
 namespace CodeImp.Bloodmasters
@@ -95,9 +94,9 @@ namespace CodeImp.Bloodmasters
 		*/
 
 		// Messages
-		private ArrayList in_reliables;
-		private ArrayList out_reliables;
-		private ArrayList out_messages;
+		private List<NetMessage> in_reliables;
+		private List<NetMessage> out_reliables;
+		private List<NetMessage> out_messages;
 
 		#endregion
 
@@ -126,14 +125,13 @@ namespace CodeImp.Bloodmasters
 			this.gateway = gateway;
 			this.address = addr;
 
-			// Create arrays
-			in_reliables = new ArrayList(MESSAGE_BUFFER_LIMIT);
-			out_reliables = new ArrayList(MESSAGE_BUFFER_LIMIT);
-			out_messages = new ArrayList(MESSAGE_BUFFER_LIMIT);
+			// Create lists
+			in_reliables = new List<NetMessage>(MESSAGE_BUFFER_LIMIT);
+			out_reliables = new List<NetMessage>(MESSAGE_BUFFER_LIMIT);
+			out_messages = new List<NetMessage>(MESSAGE_BUFFER_LIMIT);
 
 			// Make random ID
-			Random rnd = new Random();
-			randomid = rnd.Next(int.MaxValue);
+			randomid = Random.Shared.Next(int.MaxValue);
 
 			// Set timeouts
 			timeout = SharedGeneral.GetCurrentTime() + DEFAULT_TIMEOUT;
@@ -395,7 +393,7 @@ namespace CodeImp.Bloodmasters
 
 		// This make packets from the outgoing messages
 		// Also performs packetloss simulation
-		public ArrayList GetPackets()
+		public List<Packet> GetPackets()
 		{
 			int i = 0;
 			int waste, msgspacked = 0;
@@ -403,7 +401,7 @@ namespace CodeImp.Bloodmasters
 			NetMessage msg;
 
 			// Make packets array
-			ArrayList packets = new ArrayList(out_messages.Count);
+			List<Packet> packets = new List<Packet>(out_messages.Count);
 
 			// Sort all messages by size, biggest first
 			out_messages.Sort(new NetMessageComparer(true));
@@ -412,7 +410,7 @@ namespace CodeImp.Bloodmasters
 			while(i < out_messages.Count)
 			{
 				// Get the current message
-				msg = (NetMessage)out_messages[i];
+				msg = out_messages[i];
 
 				// Check if this message must be sent now
 				if(msg.SimSendTime <= SharedGeneral.GetCurrentTime())
@@ -493,8 +491,7 @@ namespace CodeImp.Bloodmasters
 				for(i = packets.Count - 1; i >= 0; i--)
 				{
 					// Randomly choose to drop this message
-					Random rnd = new Random();
-					if(rnd.Next((int)(10000f / (float)gateway.SimulateLoss)) < 100)
+                    if(Random.Shared.Next((int)(10000f / (float)gateway.SimulateLoss)) < 100)
 					{
 						// Remove packet
 						packets.RemoveAt(i);

--- a/Source/Shared/Net/NetMessageComparer.cs
+++ b/Source/Shared/Net/NetMessageComparer.cs
@@ -10,30 +10,25 @@ using System.Text;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters
 {
-	public class NetMessageComparer : IComparer
+	public class NetMessageComparer : IComparer<NetMessage>
 	{
 		bool reversed = false;
-		
+
 		// Constructor
 		public NetMessageComparer(bool reversed)
 		{
 			// Apply settings
 			this.reversed = reversed;
 		}
-		
+
 		// Compare two NetMessages
-		public int Compare(object x, object y)
+		public int Compare(NetMessage m1, NetMessage m2)
 		{
-			// Get proper message objects
-			NetMessage m1 = (NetMessage)x;
-			NetMessage m2 = (NetMessage)y;
-			
-			// Check if sorting reversed
+            // Check if sorting reversed
 			if(reversed)
 			{
 				// Compare difference in size

--- a/Source/Shared/Net/Packet.cs
+++ b/Source/Shared/Net/Packet.cs
@@ -14,7 +14,7 @@ Packet:
 
 Multiple messages combined and converted to a single data
 stream, ready for transmitting over the network.
-	
+
 */
 
 using System;
@@ -22,7 +22,6 @@ using System.Text;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters
@@ -30,55 +29,55 @@ namespace CodeImp.Bloodmasters
 	public class Packet
 	{
 		#region ================== Constants
-		
+
 		// Maximum optimal size in bytes
 		private const int MAX_OPTIMAL_SIZE = 300;
-		
+
 		#endregion
-		
+
 		#region ================== Variables
-		
+
 		// Target/source address
 		private IPEndPoint address;
-		
+
 		// Packet data
 		private MemoryStream data = null;
-		
+
 		#endregion
-		
+
 		#region ================== Properties
-		
+
 		public IPEndPoint Address { get { return address; } }
 		public int Length { get { return (int)data.Length; } }
 		public int OptimalSpaceLeft { get { return MAX_OPTIMAL_SIZE - (int)data.Length; } }
-		
+
 		#endregion
-		
+
 		#region ================== Constructor
-		
+
 		// Constructor for new packet
 		public Packet(IPEndPoint addr)
 		{
 			// Set the address
 			this.address = addr;
-			
+
 			// Make data stream
 			data = new MemoryStream(MAX_OPTIMAL_SIZE);
 		}
-		
+
 		// Constructor for new packet
 		public Packet(IPEndPoint addr, byte[] newdata)
 		{
 			// Set the address
 			this.address = addr;
-			
+
 			// Make data stream
 			data = new MemoryStream(MAX_OPTIMAL_SIZE);
-			
+
 			// Append the new data
 			AppendData(newdata);
 		}
-		
+
 		// Disposer
 		public void Dispose()
 		{
@@ -87,25 +86,25 @@ namespace CodeImp.Bloodmasters
 			data = null;
 			GC.SuppressFinalize(this);
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Methods
-		
+
 		// This appends data to the stream
 		public void AppendData(byte[] newdata)
 		{
 			// Write data to stream
 			data.Write(newdata, 0, newdata.Length);
 		}
-		
+
 		// This returns all stream data
 		public byte[] GetData()
 		{
 			// Return stream data
 			return data.ToArray();
 		}
-		
+
 		#endregion
 	}
 }

--- a/Source/Shared/PhysicsState.cs
+++ b/Source/Shared/PhysicsState.cs
@@ -7,9 +7,6 @@
 
 // This controls the physics in the game
 
-using System.Collections;
-using System.Collections.Generic;
-
 namespace CodeImp.Bloodmasters
 {
 	public abstract class PhysicsState
@@ -84,64 +81,30 @@ namespace CodeImp.Bloodmasters
 		// Returns true when collided with a wall
 		public bool ApplyVelocity(bool wallcollisions)
 		{
-			ArrayList clientslist = null;
-			Sidedef crossline = null;
-			return ApplyVelocity(wallcollisions, false, clientslist, null, out crossline);
+            return ApplyVelocity(wallcollisions, false, null, null, out _);
 		}
 
 		// This moves the position with the total velocity.
 		// Returns true when collided with a wall
 		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-						IPhysicsState[] allclients, IPhysicsState thisclient)
+						IReadOnlyList<IPhysicsState> allclients, IPhysicsState thisclient)
 		{
-			ArrayList clientslist = new ArrayList(allclients);
-			Sidedef crossline = null;
-			return ApplyVelocity(wallcollisions, clientcollisions, clientslist, thisclient, out crossline);
+            return ApplyVelocity(wallcollisions, clientcollisions, allclients, thisclient, out _);
 		}
 
 		// This moves the position with the total velocity.
 		// Returns true when collided with a wall
 		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-						IPhysicsState[] allclients, IPhysicsState thisclient,
+						IReadOnlyList<IPhysicsState> allclients, IPhysicsState thisclient,
 						out Sidedef crossline)
 		{
-			ArrayList clientslist = new ArrayList(allclients);
-			return ApplyVelocity(wallcollisions, clientcollisions, clientslist, thisclient, out crossline);
+            return ApplyVelocity(wallcollisions, clientcollisions, allclients, thisclient, out crossline, out _);
 		}
 
-		// This moves the position with the total velocity.
+        // This moves the position with the total velocity.
 		// Returns true when collided with a wall
 		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-						IPhysicsState[] allclients, IPhysicsState thisclient,
-						out Sidedef crossline, out object hitobj)
-		{
-			ArrayList clientslist = new ArrayList(allclients);
-			return ApplyVelocity(wallcollisions, clientcollisions, clientslist, thisclient, out crossline, out hitobj);
-		}
-
-		// This moves the position with the total velocity.
-		// Returns true when collided with a wall
-		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-								ArrayList allclients, IPhysicsState thisclient)
-		{
-			Sidedef crossline = null;
-			return ApplyVelocity(wallcollisions, clientcollisions, allclients, thisclient, out crossline);
-		}
-
-		// This moves the position with the total velocity.
-		// Returns true when collided with a wall
-		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-								ArrayList allclients, IPhysicsState thisclient,
-								out Sidedef crossline)
-		{
-			object obj = null;
-			return ApplyVelocity(wallcollisions, clientcollisions, allclients, thisclient, out crossline, out obj);
-		}
-
-		// This moves the position with the total velocity.
-		// Returns true when collided with a wall
-		public bool ApplyVelocity(bool wallcollisions, bool clientcollisions,
-								ArrayList allclients, IPhysicsState thisclient,
+								IReadOnlyList<IPhysicsState> allclients, IPhysicsState thisclient,
 								out Sidedef crossline, out object hitobj)
 		{
 			float stepheight;
@@ -191,11 +154,11 @@ namespace CodeImp.Bloodmasters
 			if(wallcollisions)
 			{
 				// Get all the nearby lines and make collisions
-				ArrayList lines = map.BlockMap.GetCollisionLines(pos.x, pos.y, tgt.x, tgt.y, radius);
+                List<Linedef> lines = map.BlockMap.GetCollisionLines(pos.x, pos.y, tgt.x, tgt.y, radius);
 				for(int i = 0; i < lines.Count; i++)
 				{
 					// Get the linedef
-					Linedef ld = (Linedef)lines[i];
+					Linedef ld = lines[i];
 
 					// Make possible collision
 					WallCollision wc = CreateWallCollision(ld, sv, stepheight);

--- a/Source/Shared/Wad.cs
+++ b/Source/Shared/Wad.cs
@@ -11,7 +11,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Collections;
 using CodeImp;
 
 namespace CodeImp.Bloodmasters
@@ -22,7 +21,7 @@ namespace CodeImp.Bloodmasters
 		public static string BytesToString(byte[] bytes)
 		{
 			int length = bytes.Length;
-			
+
 			// Find the first null byte
 			for(int i = 0; i < bytes.Length; i++)
 			{
@@ -34,26 +33,26 @@ namespace CodeImp.Bloodmasters
 					break;
 				}
 			}
-			
+
 			// Make the string
 			return Encoding.ASCII.GetString(bytes, 0, length);
 		}
-		
+
 		// This returns a file stream for the given lump name
 		public static BinaryReader ReadLump(string wadfile, string lumpname)
 		{
 			int i;
-			
+
 			// Open the WAD file
 			FileStream f = File.OpenRead(wadfile);
 			BinaryReader bf = new BinaryReader(f);
-			
+
 			// Get the number of lumps and the offset to
 			// the lump metadata
 			f.Seek(4, SeekOrigin.Begin);
 			int numlumps = bf.ReadInt32();
 			int mdoffset = bf.ReadInt32();
-			
+
 			// Go for all lumps
 			f.Seek(mdoffset, SeekOrigin.Begin);
 			for(i = 0; i < numlumps; i++)
@@ -62,7 +61,7 @@ namespace CodeImp.Bloodmasters
 				int lpoffset = bf.ReadInt32();
 				int lpsize = bf.ReadInt32();
 				byte[] lpname = bf.ReadBytes(8);
-				
+
 				// Check if this is the lump we need
 				string lpstrname = Encoding.ASCII.GetString(lpname);
 				if(lpstrname.ToLower().StartsWith(lumpname.ToLower()))
@@ -71,20 +70,20 @@ namespace CodeImp.Bloodmasters
 					f.Seek(lpoffset, SeekOrigin.Begin);
 					byte[] lpdata = bf.ReadBytes(lpsize);
 					MemoryStream ms = new MemoryStream(lpdata, false);
-					
+
 					// Close file
 					bf.Close();
 					f.Close();
-					
+
 					// Return memory stream wrapped in a binary reader
 					return new BinaryReader(ms);
 				}
 			}
-			
+
 			// Close file
 			bf.Close();
 			f.Close();
-			
+
 			// Return nothing
 			return null;
 		}


### PR DESCRIPTION
Closes #67

I've left 2 TODOs in places that look suspicious after using generics:
- https://github.com/ForNeVeR/bloodmasters/pull/69/files?diff=split&w=1#diff-63d82d11e161d072b19aa322d3581f5a9d7209807cc6525e786553e34521228fR558
- https://github.com/ForNeVeR/bloodmasters/pull/69/files?diff=split&w=1#diff-2af96f2a40d7ff2d49898ff02993b74427baec3984ec7968620ba41b60ac67a6R134

I also reviewed remaining references to `System.Collections` namespace, and most of them are related to `Configuration` usage (filled https://github.com/ForNeVeR/bloodmasters/issues/68 to address that), and last one comes from `GamesListItemComparer : IComparer` (which is ok, as winforms `ListViewItemSorter` expects non-generic version)

NOTE: after review, I will squash all these commits to one with issue number