### PR TITLE
(#70) Fix directx reset call

### DIFF
--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using SharpDX;
 using SharpDX.Direct3D9;
@@ -1627,7 +1628,7 @@ namespace CodeImp.Bloodmasters.Client
                 var displayModeFilter = new DisplayModeFilter
                 {
                     Format = format,
-                    Size = System.Runtime.CompilerServices.Unsafe.SizeOf<DisplayModeFilter>(),
+                    Size = Unsafe.SizeOf<DisplayModeFilter>(),
                 };
 
                 var count = direct3d.GetAdapterModeCountEx(a.Adapter, displayModeFilter);

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -1109,71 +1109,7 @@ namespace CodeImp.Bloodmasters.Client
 			GC.Collect();
 		}
 
-		// This resets the device
-		public static bool Reset()
-		{
-			// The desktop resolution may have changed, which
-			// also changes our mode restrictions for windowed mode.
-			// We must find the closest mode match again.
-
-			// Find the exact or closest matching display mode.
-			// This also sets the format to the current
-			// display format for windowed mode.
-			if(FindDisplayMode(displaymode, displaywindowed, displayfsaa))
-			{
-				// Trash the backbuffer
-				backbuffer.Dispose();
-				backbuffer = null;
-				depthbuffer.Dispose();
-				depthbuffer = null;
-
-				// Trash stateblocks
-				try { sb_nalpha.Dispose(); } catch(Exception) {} sb_nalpha = null;
-				try { sb_nadditivealpha.Dispose(); } catch(Exception) {} sb_nadditivealpha = null;
-				try { sb_tlmodalpha.Dispose(); } catch(Exception) {} sb_tlmodalpha = null;
-				try { sb_nlightmap.Dispose(); } catch(Exception) {} sb_nlightmap = null;
-				try { sb_nlightmapalpha.Dispose(); } catch(Exception) {} sb_nlightmapalpha = null;
-				try { sb_tllightdraw.Dispose(); } catch(Exception) {} sb_tllightdraw = null;
-				try { sb_tllightblend.Dispose(); } catch(Exception) {} sb_tllightblend = null;
-				try { sb_nlines.Dispose(); } catch(Exception) {} sb_nlines = null;
-				try { sb_pnormal.Dispose(); } catch(Exception) {} sb_pnormal = null;
-				try { sb_padditive.Dispose(); } catch(Exception) {} sb_padditive = null;
-				try { sb_nlightblend.Dispose(); } catch(Exception) {} sb_nlightblend = null;
-
-				// Choose most appropriate lightmap format
-				ChooseLightmapFormat();
-
-				// Create presentation parameters
-				displaypp = CreatePresentParameters(displaymode, displaywindowed, displaysyncrefresh, displayfsaa);
-
-				// Adjust rendertarget to display mode
-				AdjustRenderTarget(adapter, displaymode, displaywindowed);
-
-				// Reset the device
-				try { d3dd.Reset(displaypp); }
-				catch(Exception) { return false; }
-
-				// Get the new backbuffer
-				backbuffer = d3dd.GetBackBuffer(0, 0);
-				depthbuffer = d3dd.DepthStencilSurface;
-
-				// Setup renderstates
-				SetupRenderstates();
-
-				// Clear the screen
-				ClearScreen();
-
-				// Success
-				return true;
-			}
-			else
-			{
-				// Failed
-				return false;
-			}
-		}
-
-		// This will initialize the Direct3D device
+        // This will initialize the Direct3D device
 		public static bool Initialize(Form target)
 		{
 			DeviceType devtype;

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -34,7 +34,7 @@ namespace CodeImp.Bloodmasters.Client
 
 		#region ================== Variables
 
-        private static SharpDX.Direct3D9.Direct3D _direct3D;
+        private static Direct3DEx _direct3D;
 
 		// Devices
 		public static Device d3dd;
@@ -44,7 +44,7 @@ namespace CodeImp.Bloodmasters.Client
 		private static AdapterInformation adapter;
 
 		// Current settings
-		private static DisplayMode displaymode;
+		private static DisplayModeEx displaymode;
 		private static bool displaywindowed;
 		private static bool displaysyncrefresh;
 		private static int displayfsaa;
@@ -88,7 +88,7 @@ namespace CodeImp.Bloodmasters.Client
 		public static bool DisplaySyncRefresh { get { return displaysyncrefresh; } set { displaysyncrefresh = value; } }
 		public static int DisplayFSAA { get { return displayfsaa; } set { displayfsaa = value; } }
 		public static int DisplayGamma { get { return displaygamma; } set { displaygamma = value; } }
-		public static DisplayMode DisplayMode { get { return displaymode; } set { displaymode = value; } }
+		public static DisplayModeEx DisplayMode { get { return displaymode; } set { displaymode = value; } }
 		public static Format LightmapFormat { get { return lightmapformat; } }
 		public static RawViewport DisplayViewport { get { return displayviewport; } }
 		public static Rectangle ScreenClipRectangle { get { return screencliprect; } }
@@ -203,12 +203,12 @@ namespace CodeImp.Bloodmasters.Client
         }
 
         // This returns a specific display mode
-        public static DisplayMode GetDisplayMode(int index)
+        public static DisplayModeEx GetDisplayMode(int index)
         {
             int counter = 0;
 
             // Enumerate all display modes
-            foreach(DisplayMode d in GetAdapterDisplayModes(adapter))
+            foreach(DisplayModeEx d in GetAdapterDisplayModes(adapter))
             {
                 // Return settings if this the mode to use
                 if(index == counter) return d;
@@ -218,14 +218,14 @@ namespace CodeImp.Bloodmasters.Client
             }
 
             // Nothing
-            return new DisplayMode();
+            return new DisplayModeEx();
         }
 		#endregion
 
 		#region ================== Capabilities Validation
 
 		// This finds the closest matching display mode
-		private static bool FindDisplayMode(ref DisplayMode mode, bool windowed, int fsaa)
+		private static bool FindDisplayMode(DisplayModeEx mode, bool windowed, int fsaa)
 		{
 			// In case windowed is true, the display format
 			// must be set to the current format
@@ -233,7 +233,7 @@ namespace CodeImp.Bloodmasters.Client
 
 			// Go for all display modes to find the one specified
             var allmodes = GetAdapterDisplayModes(adapter);
-			foreach(DisplayMode dm in allmodes)
+			foreach(DisplayModeEx dm in allmodes)
 			{
 				// Check if this is the same mode
 				if((dm.Width == mode.Width) &&
@@ -255,7 +255,7 @@ namespace CodeImp.Bloodmasters.Client
 			// try searching again, but disregard the refreshrate.
 			// Go for all display modes to find a matching mode
             allmodes = GetAdapterDisplayModes(adapter);
-			foreach(DisplayMode dm in allmodes)
+			foreach(DisplayModeEx dm in allmodes)
 			{
 				// Check if this is the same mode
 				if((dm.Width == mode.Width) &&
@@ -276,7 +276,7 @@ namespace CodeImp.Bloodmasters.Client
 			// try searching again, but disregard refreshrate and format.
 			// Go for all display modes to find a matching mode
             allmodes = GetAdapterDisplayModes(adapter);
-			foreach(DisplayMode dm in allmodes)
+			foreach(DisplayModeEx dm in allmodes)
 			{
 				// Check if this is the same mode
 				if((dm.Width == mode.Width) &&
@@ -296,7 +296,7 @@ namespace CodeImp.Bloodmasters.Client
 			// Then just pick the first valid one.
 			// Go for all display modes to find the first valid mode
             allmodes = GetAdapterDisplayModes(adapter);
-			foreach(DisplayMode dm in allmodes)
+			foreach(DisplayModeEx dm in allmodes)
 			{
 				// Check if this format is supported
 				if(ValidateDisplayMode(dm, windowed))
@@ -313,7 +313,7 @@ namespace CodeImp.Bloodmasters.Client
 
         // This tests if the given display mode is supported and
         // if it supports everything this engine needs
-        public static bool ValidateDisplayMode(DisplayMode mode, bool windowed)
+        public static bool ValidateDisplayMode(DisplayModeEx mode, bool windowed)
         {
             // The resolution must be at least 640x480
             if((mode.Width < 640) || (mode.Height < 480)) return false;
@@ -452,9 +452,9 @@ namespace CodeImp.Bloodmasters.Client
         public static void InitDX()
         {
             // Initialize variables
-            _direct3D = new SharpDX.Direct3D9.Direct3D();
+            _direct3D = new Direct3DEx();
             adapter = _direct3D.Adapters[0];
-            displaymode = new DisplayMode();
+            displaymode = new DisplayModeEx();
         }
 
         public static void DeinitDirectX()
@@ -1119,7 +1119,7 @@ namespace CodeImp.Bloodmasters.Client
 			// Find the exact or closest matching display mode.
 			// This also sets the format to the current
 			// display format for windowed mode.
-			if(FindDisplayMode(ref displaymode, displaywindowed, displayfsaa))
+			if(FindDisplayMode(displaymode, displaywindowed, displayfsaa))
 			{
 				// Trash the backbuffer
 				backbuffer.Dispose();
@@ -1194,7 +1194,7 @@ namespace CodeImp.Bloodmasters.Client
 			// Find the exact or closest matching display mode.
 			// This also sets the format to the current
 			// display format for windowed mode.
-			if(FindDisplayMode(ref displaymode, displaywindowed, displayfsaa))
+			if(FindDisplayMode(displaymode, displaywindowed, displayfsaa))
 			{
 				// Choose most appropriate lightmap format
 				ChooseLightmapFormat();
@@ -1268,7 +1268,7 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// This creates presentation parameters for the requested mode
-		private static PresentParameters CreatePresentParameters(DisplayMode mode, bool windowed, bool syncrefresh, int fsaa)
+		private static PresentParameters CreatePresentParameters(DisplayModeEx mode, bool windowed, bool syncrefresh, int fsaa)
 		{
 			// Create the presentation parameters
 			PresentParameters d3dpp = new PresentParameters();
@@ -1316,7 +1316,7 @@ namespace CodeImp.Bloodmasters.Client
 		}
 
 		// Adjust the rendertarget to match with the display mode
-		private static void AdjustRenderTarget(AdapterInformation ad, DisplayMode mode, bool windowed)
+		private static void AdjustRenderTarget(AdapterInformation ad, DisplayModeEx mode, bool windowed)
 		{
 			// Get device caps
 			var dc = _direct3D.GetDeviceCaps(ad.Adapter, DeviceType.Hardware);
@@ -1423,34 +1423,11 @@ namespace CodeImp.Bloodmasters.Client
 				var coopresult = d3dd.TestCooperativeLevel();
 
 				// Check if device must be reset
-				if(coopresult == (int)ResultCode.DeviceNotReset)
-				{
-					// Device is lost and must be reset now
-
-					// Release all Direct3D resources
-					UnloadAllResources();
-
-					// Reset the device
-					if(Direct3D.Reset())
-					{
-						// Reload all Direct3D resources
-						ReloadAllResources();
-
-						// Success
-						return true;
-					}
-					else
-					{
-						// Failed
-						return false;
-					}
-				}
-				// Check if device is lost
-				else if(coopresult == (int)ResultCode.DeviceLost)
-				{
-					// Device is lost and cannot be reset now
-					return false;
-				}
+                if(coopresult == (int)ResultCode.DeviceLost)
+                {
+                    // Device is lost and cannot be reset now
+                    return false;
+                }
 
 				// Clear the screen
 				d3dd.Clear(ClearFlags.Target | ClearFlags.ZBuffer, new(), 1f, 0);
@@ -1545,7 +1522,7 @@ namespace CodeImp.Bloodmasters.Client
 				{
 					// Load texture file
 					t =  Texture.FromFile(d3dd, Path.Combine(General.apppath, filename), width, height, mipmaplevels, Usage.None, Format.Unknown,
-												Pool.Managed, Filter.Linear | Filter.MirrorU | Filter.MirrorV | Filter.Dither,
+												Pool.Default, Filter.Linear | Filter.MirrorU | Filter.MirrorV | Filter.Dither,
 												Filter.Triangle, 0, out i);
 
 					// Make resource
@@ -1576,7 +1553,7 @@ namespace CodeImp.Bloodmasters.Client
 			if(mipmap) mipmaplevels = 2;
 
 			// Create texture
-			t = new Texture(d3dd, width, height, mipmaplevels, Usage.None, format, Pool.Managed);
+			t = new Texture(d3dd, width, height, mipmaplevels, Usage.None, format, Pool.Default);
 
 			// Create texture information
 			i.Format = format;
@@ -1705,16 +1682,22 @@ namespace CodeImp.Bloodmasters.Client
 
 		#region ================== Tools
 
-        private static List<DisplayMode> GetAdapterDisplayModes(AdapterInformation a)
+        private static List<DisplayModeEx> GetAdapterDisplayModes(AdapterInformation a)
         {
             var direct3d = _direct3D;
-            var displayModes = new List<DisplayMode>();
+            var displayModes = new List<DisplayModeEx>();
             foreach (var format in Enum.GetValues<Format>())
             {
-                var count = direct3d.GetAdapterModeCount(a.Adapter, format);
+                var displayModeFilter = new DisplayModeFilter
+                {
+                    Format = format,
+                    Size = System.Runtime.CompilerServices.Unsafe.SizeOf<DisplayModeFilter>(),
+                };
+
+                var count = direct3d.GetAdapterModeCountEx(a.Adapter, displayModeFilter);
                 for (var i = 0; i < count; ++i)
                 {
-                    var mode = direct3d.EnumAdapterModes(adapter.Adapter, format, i);
+                    var mode = direct3d.EnumerateAdapterModesEx(adapter.Adapter, displayModeFilter, i);
                     displayModes.Add(mode);
                 }
             }
@@ -1742,7 +1725,7 @@ namespace CodeImp.Bloodmasters.Client
 			// Copy data from S to T
 			var gs = Texture.ToStream(s, ImageFileFormat.Bmp);
 			Texture t = Texture.FromStream(Direct3D.d3dd, gs, info.Width, info.Height,
-												1, Usage.None, info.Format, Pool.Managed,
+												1, Usage.None, info.Format, Pool.Default,
 												Filter.Linear, Filter.Linear, 0);
 
 			// Clean up

--- a/Source/Client/Graphics/VisualSector.cs
+++ b/Source/Client/Graphics/VisualSector.cs
@@ -693,7 +693,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// Create vertex buffer
 				mapvertices = new VertexBuffer(Direct3D.d3dd, sizeof(MVertex) * verts.Count,
-							Usage.WriteOnly, MVertex.Format, Pool.Managed);
+							Usage.WriteOnly, MVertex.Format, Pool.Default);
 
 				// Lock vertex buffer
 				var vertsa = mapvertices.Lock<MVertex>(0, verts.Count);

--- a/Source/Launcher/General/Direct3D.cs
+++ b/Source/Launcher/General/Direct3D.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using SharpDX.Direct3D9;
 
@@ -24,13 +25,13 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		#region ================== Variables
 
-        private static SharpDX.Direct3D9.Direct3D _direct3D9Ex;
+        private static Direct3DEx _direct3D9Ex;
 
 		// Devices
 		private static int adapterIndex;
 
 		// Current settings
-		private static DisplayMode displaymode;
+		private static DisplayModeEx displaymode;
 		private static bool displaywindowed;
 		private static bool displaysyncrefresh;
 		private static int displayfsaa;
@@ -49,7 +50,7 @@ namespace CodeImp.Bloodmasters.Launcher
 		public static bool DisplaySyncRefresh { get { return displaysyncrefresh; } set { displaysyncrefresh = value; } }
 		public static int DisplayFSAA { get { return displayfsaa; } set { displayfsaa = value; } }
 		public static int DisplayGamma { get { return displaygamma; } set { displaygamma = value; } }
-		public static DisplayMode DisplayMode { get { return displaymode; } set { displaymode = value; } }
+		public static DisplayModeEx DisplayMode { get { return displaymode; } set { displaymode = value; } }
 
 		#endregion
 
@@ -254,119 +255,13 @@ namespace CodeImp.Bloodmasters.Launcher
 			General.config.WriteSetting("displaydriver", adapterIndex);
 		}
 
-		// This returns a specific display mode
-		public static DisplayMode GetDisplayMode(int index)
-		{
-			int counter = 0;
-
-			// Enumerate all display modes
-			foreach(DisplayMode d in GetAdapterDisplayModes(adapterIndex))
-			{
-				// Return settings if this the mode to use
-				if(index == counter) return d;
-
-				// Next mode
-				counter++;
-			}
-
-			// Nothing
-			return new DisplayMode();
-		}
-
-		#endregion
+        #endregion
 
 		#region ================== Capabilities Validation
 
-		// This finds the closest matching display mode
-		private static bool FindDisplayMode(ref DisplayMode mode, bool windowed, int fsaa)
-		{
-			// In case windowed is true, the display format
-			// must be set to the current format
-			if(windowed) mode.Format = _direct3D9Ex.GetAdapterDisplayMode(adapterIndex).Format;
-
-			// Go for all display modes to find the one specified
-			var allmodes = GetAdapterDisplayModes(adapterIndex);
-			foreach(DisplayMode dm in allmodes)
-			{
-				// Check if this is the same mode
-				if((dm.Width == mode.Width) &&
-				   (dm.Height == mode.Height) &&
-				   (dm.Format == mode.Format) &&
-				   (dm.RefreshRate == mode.RefreshRate))
-				{
-					// Check if this format is supported
-					if(ValidateDisplayMode(dm, windowed))
-					{
-						// Set display mode and return success
-						mode = dm;
-						return true;
-					}
-				}
-			}
-
-			// If the exact mode could not be found,
-			// try searching again, but disregard the refreshrate.
-			// Go for all display modes to find a matching mode
-			allmodes = GetAdapterDisplayModes(adapterIndex);
-			foreach(DisplayMode dm in allmodes)
-			{
-				// Check if this is the same mode
-				if((dm.Width == mode.Width) &&
-				   (dm.Height == mode.Height) &&
-				   (dm.Format == mode.Format))
-				{
-					// Check if this format is supported
-					if(ValidateDisplayMode(dm, windowed))
-					{
-						// Set display mode and return success
-						mode = dm;
-						return true;
-					}
-				}
-			}
-
-			// If the mode can still not be found,
-			// try searching again, but disregard refreshrate and format.
-			// Go for all display modes to find a matching mode
-			allmodes = GetAdapterDisplayModes(adapterIndex);
-			foreach(DisplayMode dm in allmodes)
-			{
-				// Check if this is the same mode
-				if((dm.Width == mode.Width) &&
-				   (dm.Height == mode.Height))
-				{
-					// Check if this format is supported
-					if(ValidateDisplayMode(dm, windowed))
-					{
-						// Set display mode and return success
-						mode = dm;
-						return true;
-					}
-				}
-			}
-
-			// Still no matching display mode found?
-			// Then just pick the first valid one.
-			// Go for all display modes to find the first valid mode
-			allmodes = GetAdapterDisplayModes(adapterIndex);
-			foreach(DisplayMode dm in allmodes)
-			{
-				// Check if this format is supported
-				if(ValidateDisplayMode(dm, windowed))
-				{
-					// Set display mode and return success
-					mode = dm;
-					return true;
-				}
-			}
-
-			// No valid mode found
-			return false;
-		}
-
-		// This tests if the given display mode is supported and
+        // This tests if the given display mode is supported and
 		// if it supports everything this engine needs
-		public static bool ValidateDisplayMode(DisplayMode mode, bool windowed)
+		public static bool ValidateDisplayMode(DisplayModeEx mode, bool windowed)
 		{
 			// The resolution must be at least 640x480
 			if((mode.Width < 640) || (mode.Height < 480)) return false;
@@ -448,9 +343,9 @@ namespace CodeImp.Bloodmasters.Launcher
 		public static void InitDX()
         {
 			// Initialize variables
-            _direct3D9Ex = new SharpDX.Direct3D9.Direct3D();
+            _direct3D9Ex = new Direct3DEx();
 			adapterIndex = 0;
-			displaymode = new DisplayMode();
+			displaymode = new DisplayModeEx();
 		}
 
         public static void DeinitDirectX()
@@ -461,15 +356,21 @@ namespace CodeImp.Bloodmasters.Launcher
 
 		#endregion
 
-        private static List<DisplayMode> GetAdapterDisplayModes(int adapter)
+        private static List<DisplayModeEx> GetAdapterDisplayModes(int adapter)
         {
-            var displayModes = new List<DisplayMode>();
+            var displayModes = new List<DisplayModeEx>();
             foreach (var format in Enum.GetValues<Format>())
             {
-                var count = _direct3D9Ex.GetAdapterModeCount(adapter, format);
+                var displayModeFilter = new DisplayModeFilter
+                {
+                    Format = format,
+                    Size = Unsafe.SizeOf<DisplayModeFilter>(),
+                };
+
+                var count = _direct3D9Ex.GetAdapterModeCountEx(adapter, displayModeFilter);
                 for (var i = 0; i < count; ++i)
                 {
-                    var mode = _direct3D9Ex.EnumAdapterModes(adapter, format, i);
+                    var mode = _direct3D9Ex.EnumerateAdapterModesEx(adapter, displayModeFilter, i);
                     displayModes.Add(mode);
                 }
             }

--- a/Source/Launcher/Interface/DisplayModeItem.cs
+++ b/Source/Launcher/Interface/DisplayModeItem.cs
@@ -12,10 +12,10 @@ namespace CodeImp.Bloodmasters.Launcher
 {
 	public struct DisplayModeItem : IComparable
 	{
-		public DisplayMode mode;
+		public DisplayModeEx mode;
 
 		// Constructor
-		public DisplayModeItem(DisplayMode m)
+		public DisplayModeItem(DisplayModeEx m)
 		{
 			mode = m;
 		}

--- a/Source/Launcher/Interface/FormOptions.cs
+++ b/Source/Launcher/Interface/FormOptions.cs
@@ -14,7 +14,7 @@ namespace CodeImp.Bloodmasters.Launcher
 	public class FormOptions : System.Windows.Forms.Form
 	{
 		private int last_fsaa;
-		private DisplayMode last_mode;
+		private DisplayModeEx last_mode;
 		private Dictionary<string, int> controlkeys = new();
 		private System.ComponentModel.Container components = null;
 		private System.Windows.Forms.Button btnOK;


### PR DESCRIPTION
So after digging a little bit (not that little to be honest), I found [this](https://stackoverflow.com/a/38864429) SO question and provided solution was not so satisfying.

Then I found [this](https://gamedev.net/forums/topic/534709-direct3d-and-direct3dex-on-vista/534709/) thread explaining differences between `Direct3D` and `Direct3DEx` (and it looked like this was it)

Switching to `Direct3DEx` caused a crash on game startup related to resources loading, and after another round of googling I found [this](https://gamedev.stackexchange.com/a/18741) answer and changed all remaining `Pool.Managed` to `Pool.Default`. And also removed `Reset` method, as it seems like we don't need it when using `Direct3DEx`

Fixes #70