### PR TITLE
Client: introduce Dev Mode build

### DIFF
--- a/.bloodmasters.dev.marker
+++ b/.bloodmasters.dev.marker
@@ -1,0 +1,3 @@
+This file enables Bloodmasters to work from the way the game files are placed in the dev mode (when built from sources).
+
+It should be copied near each game binary for it to detect the dev mode.

--- a/.bloodmasters.solution-root.marker
+++ b/.bloodmasters.solution-root.marker
@@ -1,0 +1,1 @@
+This file shows the solution root of the Bloodmasters source layout. All the other entries will be looked up relatively to the directory containing this file.

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@
 bin/
 obj/
 
+/Build/*.debug.cfg
+/Build/*.marker
+/Build/**/publish/*
 /Build/**/*.dll
 /Build/**/*.exe
 /Build/**/*.json
 /Build/**/*.pdb
-/Build/*.debug.cfg
-/Build/**/publish/*
-/Build/*.marker
 
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ obj/
 /Build/**/*.pdb
 /Build/*.debug.cfg
 /Build/**/publish/*
+/Build/*.marker
 
 *.user

--- a/Source/Bloodmasters.sln
+++ b/Source/Bloodmasters.sln
@@ -28,6 +28,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
+		..\.bloodmasters.dev.marker = ..\.bloodmasters.dev.marker
+		..\.bloodmasters.solution-root.marker = ..\.bloodmasters.solution-root.marker
+		..\.gitignore = ..\.gitignore
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bloodmasters.Server", "Server\Bloodmasters.Server.csproj", "{34A2FA5F-08A5-4464-82AD-BEC71C200352}"

--- a/Source/Client/.bloodmasters.dev.marker
+++ b/Source/Client/.bloodmasters.dev.marker
@@ -1,0 +1,1 @@
+This file enables Bloodmasters to work from the way the binaries are laid out in dev mode (when built from sources).

--- a/Source/Client/.bloodmasters.dev.marker
+++ b/Source/Client/.bloodmasters.dev.marker
@@ -1,1 +1,0 @@
-This file enables Bloodmasters to work from the way the binaries are laid out in dev mode (when built from sources).

--- a/Source/Client/Bloodmasters.Client.csproj
+++ b/Source/Client/Bloodmasters.Client.csproj
@@ -17,7 +17,6 @@
         <OutputPath>..\..\Build\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>11</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="Bloodmasters.Tests" />

--- a/Source/Client/Bloodmasters.Client.csproj
+++ b/Source/Client/Bloodmasters.Client.csproj
@@ -25,12 +25,14 @@
         <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
     </ItemGroup>
     <ItemGroup>
-        <None Update=".bloodmasters.dev.marker" CopyToOutputDirectory="PreserveNewest" />
         <None Update="client-standalone.debug.cfg" CopyToOutputDirectory="PreserveNewest" />
         <None Update="server.debug.cfg" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Server\Bloodmasters.Server.csproj" />
         <ProjectReference Include="..\Shared\Bloodmasters.Shared.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="..\..\.bloodmasters.dev.marker" CopyToOutputDirectory="Always"/>
     </ItemGroup>
 </Project>

--- a/Source/Client/Bloodmasters.Client.csproj
+++ b/Source/Client/Bloodmasters.Client.csproj
@@ -14,8 +14,6 @@
     <PropertyGroup>
         <ApplicationIcon>..\..\Resources\bm.ico</ApplicationIcon>
         <RootNamespace>CodeImp.Bloodmasters.Client</RootNamespace>
-        <OutputPath>..\..\Build\</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
@@ -27,6 +25,7 @@
         <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
     </ItemGroup>
     <ItemGroup>
+        <None Update=".bloodmasters.dev.marker" CopyToOutputDirectory="PreserveNewest" />
         <None Update="client-standalone.debug.cfg" CopyToOutputDirectory="PreserveNewest" />
         <None Update="server.debug.cfg" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>

--- a/Source/Client/General/Arena.cs
+++ b/Source/Client/General/Arena.cs
@@ -482,7 +482,7 @@ namespace CodeImp.Bloodmasters.Client
 			int dynvissecs = 0;
 
 			// Open file for writing
-			FileStream outfile = File.Open(Path.Combine(General.apppath, "mapinfo.txt"),
+			FileStream outfile = File.Open(Path.Combine(Paths.LogDirPath, "mapinfo.txt"),
 				FileMode.Create, FileAccess.Write, FileShare.Read);
 			StreamWriter writer = new StreamWriter(outfile);
 

--- a/Source/Client/General/GConsole.cs
+++ b/Source/Client/General/GConsole.cs
@@ -664,7 +664,7 @@ namespace CodeImp.Bloodmasters.Client
 		{
 			// Make path and filename
 			string filename = General.mapname + "_" + DateTime.Now.ToString("MM\\_dd\\_yyyy\\_HH\\_mm\\_ss") + ".png";
-			string pathname = Path.Combine(General.apppath, "Screenshots");
+			string pathname = Path.Combine(Paths.ScreenshotsDirPath);
 			string filepathname = Path.Combine(pathname, filename);
 
 			// Ensure screenshots directory exists
@@ -905,8 +905,8 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				try
 				{
-					// When no path given, write to current directory
-					Directory.SetCurrentDirectory(General.apppath);
+					// When no path given, write to the log directory
+					Directory.SetCurrentDirectory(Paths.LogDirPath);
 
 					// Open the log file
 					log = File.CreateText(args);

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -53,8 +53,6 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Variables
 
 		// Application paths and name
-        // TODO: Remove apppath from here
-		public static string apppath = "";
 		public static string appname = "";
 		public static string temppath = "";
 
@@ -154,10 +152,6 @@ namespace CodeImp.Bloodmasters.Client
 			Application.EnableVisualStyles();
 			Application.DoEvents();		// This must be here to work around a .NET bug
 
-			// Setup application path
-			Uri localpath = new Uri(Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetName().CodeBase), true);
-			apppath = localpath.AbsolutePath;
-
 			// Setup application name
 			appname = Assembly.GetExecutingAssembly().GetName().Name;
 
@@ -169,16 +163,16 @@ namespace CodeImp.Bloodmasters.Client
 			Directory.CreateDirectory(temppath);
 
 			// Ensure a Music directory exists
-			string musicdir = Path.Combine(General.apppath, "Music");
+			string musicdir = Path.Combine(Paths.BundledResourceDir, "Music");
 			if(!Directory.Exists(musicdir)) Directory.CreateDirectory(musicdir);
 
 			// Open all archives with archivemanager
-			ArchiveManager.Initialize(General.apppath, General.temppath);
-			ArchiveManager.OpenArchive(Path.Combine(General.apppath, "sprites"));
+			ArchiveManager.Initialize(Paths.BundledResourceDir, General.temppath);
+			ArchiveManager.OpenArchive(Path.Combine(Paths.BundledResourceDir, "sprites"));
 
 			// Setup filenames
-			configfilename = Path.Combine(General.apppath, configfilename);
-			logfilename = Path.Combine(apppath, appname + ".log");
+			configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
+			logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
 
 			// Get the high resolution clock frequency
             timefrequency = TimeProvider.System.TimestampFrequency;
@@ -393,7 +387,7 @@ namespace CodeImp.Bloodmasters.Client
 			if(!File.Exists(allargs))
 			{
 				// Try in local path
-				if(!File.Exists(Path.Combine(apppath, allargs)))
+				if(!File.Exists(Path.Combine(Paths.ConfigDirPath, allargs)))
 				{
 					// Cannot find configuration
 					MessageBox.Show("Unable to load the configuration file " + Path.GetFileName(allargs) + ".", Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -402,7 +396,7 @@ namespace CodeImp.Bloodmasters.Client
 				else
 				{
 					// Its in the local path
-					allargs = Path.Combine(apppath, allargs);
+					allargs = Path.Combine(Paths.ConfigDirPath, allargs);
 				}
 			}
 
@@ -2263,7 +2257,7 @@ namespace CodeImp.Bloodmasters.Client
                                     serverrunning = true;
 
                                     // Correct path if needed
-                                    if (!File.Exists(hostfile)) hostfile = Path.Combine(apppath, hostfile);
+                                    if (!File.Exists(hostfile)) hostfile = Path.Combine(Paths.ConfigDirPath, hostfile);
 
                                     // Load server configuration
                                     Configuration scfg = new Configuration(true);
@@ -2285,7 +2279,7 @@ namespace CodeImp.Bloodmasters.Client
                                     serverrunning = true;
 
                                     // Correct path if needed
-                                    if (!File.Exists(dedfile)) hostfile = Path.Combine(apppath, dedfile);
+                                    if (!File.Exists(dedfile)) hostfile = Path.Combine(Paths.ConfigDirPath, dedfile);
 
                                     // Load server configuration
                                     Configuration scfg = new Configuration(true);

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -2213,7 +2213,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// No proper commands given
 				// Run the standard launcher
-                Process.Start(Paths.LauncherPath);
+                Process.Start(Paths.LauncherExecutablePath);
 				return;
 			}
 

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -53,6 +53,7 @@ namespace CodeImp.Bloodmasters.Client
 		#region ================== Variables
 
 		// Application paths and name
+        // TODO: Remove apppath from here
 		public static string apppath = "";
 		public static string appname = "";
 		public static string temppath = "";
@@ -2212,8 +2213,7 @@ namespace CodeImp.Bloodmasters.Client
 			{
 				// No proper commands given
 				// Run the standard launcher
-				try { Process.Start(Path.Combine(apppath, "BMLauncher.exe")); }
-				catch(Exception) { }
+                Process.Start(Paths.LauncherPath);
 				return;
 			}
 

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -1447,7 +1447,7 @@ namespace CodeImp.Bloodmasters.Client
 			if(mipmap) mipmaplevels = 2;
 
 			// Check if the file exists
-			if(File.Exists(Path.Combine(General.apppath, filename)))
+			if(File.Exists(Path.Combine(Paths.BundledResourceDir, filename)))
 			{
 				// Check if already loaded
 				if((textures.TryGetValue(filename, out TextureResource textureResource)) && (usecache == true))
@@ -1458,7 +1458,7 @@ namespace CodeImp.Bloodmasters.Client
 				else
 				{
 					// Load texture file
-					t =  Texture.FromFile(d3dd, Path.Combine(General.apppath, filename), width, height, mipmaplevels, Usage.None, Format.Unknown,
+					t =  Texture.FromFile(d3dd, Path.Combine(Paths.BundledResourceDir, filename), width, height, mipmaplevels, Usage.None, Format.Unknown,
 												Pool.Default, Filter.Linear | Filter.MirrorU | Filter.MirrorV | Filter.Dither,
 												Filter.Triangle, 0, out i);
 

--- a/Source/Client/Sound/Jukebox.cs
+++ b/Source/Client/Sound/Jukebox.cs
@@ -43,7 +43,7 @@ namespace CodeImp.Bloodmasters.Client
 			volume = (float)General.config.ReadSetting("musicvolume", 50) / 100f;
 
 			// Make playlist from directory
-			string musicdir = Path.Combine(General.apppath, "Music");
+			string musicdir = Path.Combine(Paths.BundledResourceDir, "Music");
 			playlist = Directory.GetFiles(musicdir, "*.mp3");
 
 			// Randomize playlist?

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,4 +4,7 @@
         <ProductName>Bloodmasters</ProductName>
         <Copyright>Pascal vd Heiden, www.codeimp.com; Copyright © Bloodmasters contributors 2023</Copyright>
     </PropertyGroup>
+    <PropertyGroup>
+        <LangVersion>11</LangVersion>
+    </PropertyGroup>
 </Project>

--- a/Source/Launcher/Bloodmasters.Launcher.csproj
+++ b/Source/Launcher/Bloodmasters.Launcher.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Bloodmasters.Shared.csproj" />
   </ItemGroup>
+  <ItemGroup>
+      <Content Include="..\..\.bloodmasters.dev.marker" CopyToOutputDirectory="Always"/>
+  </ItemGroup>
 </Project>

--- a/Source/Launcher/General/General.cs
+++ b/Source/Launcher/General/General.cs
@@ -27,7 +27,6 @@ namespace CodeImp.Bloodmasters.Launcher
 		#region ================== Variables
 
 		// Paths and names
-		public static string apppath = "";
 		public static string appname = "";
 		public static string temppath = "";
 
@@ -67,10 +66,6 @@ namespace CodeImp.Bloodmasters.Launcher
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
 			Application.DoEvents();		// This must be here to work around a .NET bug
 
-			// Setup application path
-			Uri localpath = new Uri(Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetName().CodeBase), true);
-			apppath = localpath.AbsolutePath;
-
 			// Setup application name
 			appname = Assembly.GetExecutingAssembly().GetName().Name;
 
@@ -82,9 +77,9 @@ namespace CodeImp.Bloodmasters.Launcher
 			Directory.CreateDirectory(temppath);
 
 			// Setup filenames
-			configfilename = Path.Combine(General.apppath, configfilename);
-			logfilename = Path.Combine(apppath, appname + ".log");
-			ip2countryfilename = Path.Combine(General.apppath, ip2countryfilename);
+			configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
+			logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
+			ip2countryfilename = Path.Combine(Paths.BundledResourceDir, ip2countryfilename);
 
 			// Initialize DirectX
 			try { Direct3D.InitDX(); }
@@ -165,7 +160,7 @@ namespace CodeImp.Bloodmasters.Launcher
 
                         // Open all archives with archivemanager
                         mainwindow.ShowStatus("Loading data archives...");
-                        ArchiveManager.Initialize(General.apppath, General.temppath);
+                        ArchiveManager.Initialize(Paths.BundledResourceDir, General.temppath);
 
                         // Refrehs maps in list
                         mainwindow.RefreshMapsLists();
@@ -404,7 +399,7 @@ namespace CodeImp.Bloodmasters.Launcher
 			mainwindow.ShowStatus("Launching game...");
 
 			// Determine launch filename
-			string launchfile = MakeUniqueFilename(apppath, "launch_", ".cfg");
+			string launchfile = MakeUniqueFilename(Paths.ConfigDirPath, "launch_", ".cfg");
 			serverfile = servfile;
 
 			// Write launch file
@@ -412,8 +407,8 @@ namespace CodeImp.Bloodmasters.Launcher
 
 			// Make the process
 			bmproc = new Process();
-			bmproc.StartInfo.WorkingDirectory = General.apppath;
-			bmproc.StartInfo.FileName = "Bloodmasters.exe";
+			bmproc.StartInfo.FileName = Paths.ClientExecutablePath;
+			bmproc.StartInfo.WorkingDirectory = Path.GetDirectoryName(Paths.ClientExecutablePath);
 			bmproc.StartInfo.Arguments = launchfile;
 			bmproc.StartInfo.CreateNoWindow = false;
 			bmproc.StartInfo.ErrorDialog = false;

--- a/Source/Launcher/Interface/FormDownload.cs
+++ b/Source/Launcher/Interface/FormDownload.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Drawing;
-using System.ComponentModel;
-using System.Windows.Forms;
+using System.IO;
 using System.Net;
 using System.Text;
-using System.IO;
+using System.Windows.Forms;
 
 namespace CodeImp.Bloodmasters.Launcher
 {
@@ -302,7 +300,7 @@ namespace CodeImp.Bloodmasters.Launcher
 			if(contentlength > 0) prgStatus.Maximum = contentlength;
 
 			// Make the file
-			filename = Path.Combine(General.apppath, server.MapName + ".rar");
+			filename = Path.Combine(Paths.DownloadedResourceDir, server.MapName + ".rar");
 			file = File.Open(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
 
 			// Get the http download

--- a/Source/Launcher/Interface/FormMain.cs
+++ b/Source/Launcher/Interface/FormMain.cs
@@ -1519,7 +1519,7 @@ namespace CodeImp.Bloodmasters.Launcher
             General.SaveConfiguration();
 
             // Make the server configuration file
-            string scfgfile = General.MakeUniqueFilename(General.apppath, "server_", ".cfg");
+            string scfgfile = General.MakeUniqueFilename(Paths.ConfigDirPath, "server_", ".cfg");
             Configuration scfg = MakeServerConfig(true);
             scfg.SaveConfiguration(scfgfile);
 
@@ -1802,7 +1802,7 @@ namespace CodeImp.Bloodmasters.Launcher
                             download.Dispose();
 
                             // Check if new file exists
-                            filename = Path.Combine(General.apppath, gitem.MapName + ".rar");
+                            filename = Path.Combine(Paths.DownloadedResourceDir, gitem.MapName + ".rar");
                             if (File.Exists(filename))
                             {
                                 // Busy!

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace CodeImp.Bloodmasters;
+
+public static class Paths
+{
+    private const string DevModeMarkerFileName = ".bloodmasters.dev.marker";
+
+    /// <summary>Directory of the entry binary.</summary>
+    /// <remarks>In dev mode, it looks like <c>Source/Client/bin/Debug/net7.0-windows/Bloodmasters.exe</c>.</remarks>
+    private static readonly string AppBaseDir = GetAppBaseDir();
+    private static string GetAppBaseDir()
+    {
+        var modulePath = Assembly.GetEntryAssembly()?.Location ?? Process.GetCurrentProcess().MainModule?.FileName;
+        if (modulePath == null) return Environment.CurrentDirectory;
+        return Path.GetDirectoryName(modulePath) ?? Environment.CurrentDirectory;
+    }
+
+    private static readonly bool IsDevModeBuild =
+        File.Exists(Path.Combine(AppBaseDir, DevModeMarkerFileName));
+
+    private static readonly string? SolutionRootPath =
+        IsDevModeBuild
+            ? Path.Combine(AppBaseDir, "../../../../../")
+            : null;
+
+    private const string LauncherExecutableFileName = "BMLauncher.exe";
+    public static readonly string LauncherPath =
+        IsDevModeBuild
+            ? Path.Combine(SolutionRootPath!, "Build", LauncherExecutableFileName)
+            : Path.Combine(AppBaseDir, LauncherExecutableFileName);
+}

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -68,4 +68,7 @@ public static class Paths
 
     /// <summary>Directory for the log files. Write access.</summary>
     public static readonly string LogDirPath = AllPurposeDirPath;
+
+    /// <summary>Directory for screenshots. Write access.</summary>
+    public static readonly string ScreenshotsDirPath = Path.Combine(AllPurposeDirPath, "Screenshots");
 }

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -6,6 +6,7 @@ namespace CodeImp.Bloodmasters;
 public static class Paths
 {
     private const string DevModeMarkerFileName = ".bloodmasters.dev.marker";
+    private const string DevSolutionRootMarkerFileName = ".bloodmasters.solution-root.marker";
     private const string TargetFrameworkForExecutables = "net7.0-windows";
     private const string BuildConfiguration =
 #if DEBUG
@@ -29,8 +30,18 @@ public static class Paths
 
     private static readonly string? SolutionRootPath =
         IsDevModeBuild
-            ? Path.Combine(AppBaseDir, "../../../../../")
+            ? FindSolutionRootRelativelyTo(AppBaseDir)
             : null;
+    private static string? FindSolutionRootRelativelyTo(string appBaseDir)
+    {
+        var currentDir = appBaseDir;
+        while (currentDir != null && !File.Exists(Path.Combine(currentDir, DevSolutionRootMarkerFileName)))
+        {
+            currentDir = Path.GetDirectoryName(currentDir);
+        }
+
+        return currentDir;
+    }
 
     private const string ClientExecutableFileName = "Bloodmasters.exe";
     public static readonly string ClientExecutablePath =
@@ -45,8 +56,8 @@ public static class Paths
                 ClientExecutableFileName)
             : Path.Combine(AppBaseDir, ClientExecutableFileName);
 
-    // TODO: Get rid of its usage.
-    private static string AllPurposeDirPath =
+    // TODO[#84]: Get rid of its usage.
+    private static readonly string AllPurposeDirPath =
         IsDevModeBuild
             ? Path.Combine(SolutionRootPath!, "Build")
             : Path.Combine(AppBaseDir);

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -6,9 +6,16 @@ namespace CodeImp.Bloodmasters;
 public static class Paths
 {
     private const string DevModeMarkerFileName = ".bloodmasters.dev.marker";
+    private const string TargetFrameworkForExecutables = "net7.0-windows";
+    private const string BuildConfiguration =
+#if DEBUG
+        "Debug";
+#else
+        "Release";
+#endif
 
     /// <summary>Directory of the entry binary.</summary>
-    /// <remarks>In dev mode, it looks like <c>Source/Client/bin/Debug/net7.0-windows/Bloodmasters.exe</c>.</remarks>
+    /// <remarks>In dev mode, it looks like <c>Source/Client/bin/Debug/net7.0-windows</c>.</remarks>
     private static readonly string AppBaseDir = GetAppBaseDir();
     private static string GetAppBaseDir()
     {
@@ -25,9 +32,40 @@ public static class Paths
             ? Path.Combine(AppBaseDir, "../../../../../")
             : null;
 
+    private const string ClientExecutableFileName = "Bloodmasters.exe";
+    public static readonly string ClientExecutablePath =
+        IsDevModeBuild
+            ? Path.Combine(
+                SolutionRootPath!,
+                "Source",
+                "Bloodmasters",
+                "bin",
+                BuildConfiguration,
+                TargetFrameworkForExecutables,
+                ClientExecutableFileName)
+            : Path.Combine(AppBaseDir, ClientExecutableFileName);
+
+    // TODO: Get rid of its usage.
+    private static string AllPurposeDirPath =
+        IsDevModeBuild
+            ? Path.Combine(SolutionRootPath!, "Build")
+            : Path.Combine(AppBaseDir);
+
     private const string LauncherExecutableFileName = "BMLauncher.exe";
-    public static readonly string LauncherPath =
+    public static readonly string LauncherExecutablePath =
         IsDevModeBuild
             ? Path.Combine(SolutionRootPath!, "Build", LauncherExecutableFileName)
             : Path.Combine(AppBaseDir, LauncherExecutableFileName);
+
+    /// <summary>Directory with the resources distributed alongside tha game. Read-only access.</summary>
+    public static readonly string BundledResourceDir = AllPurposeDirPath;
+
+    /// <summary>Directory for the downloaded resources. Read + write access.</summary>
+    public static readonly string DownloadedResourceDir = AllPurposeDirPath;
+
+    /// <summary>Directory with the game configuration files. Read + write access.</summary>
+    public static readonly string ConfigDirPath = AllPurposeDirPath;
+
+    /// <summary>Directory for the log files. Write access.</summary>
+    public static readonly string LogDirPath = AllPurposeDirPath;
 }


### PR DESCRIPTION
First part of #11.

This will allow the client binary to work from the default.NET build location if it detects dev mode build.

(The "Dev Mode" is when we detect `.bloodmasters.dev.marker` in the binary path.)

## TODO
- [x] Make Launcher to see the game binary in the right path
- [x] Make the client find the maps and resources properly in the `Build` directory
- [x] Get rid of `apppath` in Client's `General` class
- [x] Create a new task to get rid of `General.temppath` everywhere
- [x] Create a new task to migrate from the all-purpose dir
- [x] Create a new task to handle download dir and bundled resource dir together