### PR TITLE
Fix spawn sound

### DIFF
--- a/Source/Client/Sound/AudioSampleProvider.cs
+++ b/Source/Client/Sound/AudioSampleProvider.cs
@@ -29,7 +29,7 @@ internal class AudioSampleProvider : ISampleProvider
     private SoundState _state;
     private int _position;
     private bool _shouldRepeat;
-    private float _volumeHundredthsOfDb = MinVolumeHundredthsOfDb;
+    private float _volumeHundredthsOfDb = MaxVolumeHundredthsOfDb;
 
     public WaveFormat WaveFormat { get; }
 


### PR DESCRIPTION
This brings back original behavior of spawn sound - I checked in the original game, and even if we set effects to 1%, the spawn sound is still being played at max volume.

If we want to fix this, we would need to set volume somewhere else, because this expression is never true for the spawn sound (both `update` and `positional` are false)

https://github.com/ForNeVeR/bloodmasters/blob/a8de4241198de8087a464d013e4a84742671f848/Source/Client/Sound/Sound.cs#L125