### PR TITLE
(#116) Set Flames sound random offset after starting playing

### DIFF
--- a/Source/Client/Projectiles/Flames.cs
+++ b/Source/Client/Projectiles/Flames.cs
@@ -67,8 +67,8 @@ public class Flames : Projectile
         // Create sound
         firesound = SoundSystem.GetSound("playerfire.wav", true);
         firesound.Position = start;
-        firesound.SetRandomOffset();
         firesound.Play(true);
+        firesound.SetRandomOffset();
     }
 
     // Dispose


### PR DESCRIPTION
Closes #116

Checked https://github.com/ForNeVeR/bloodmasters/blob/1f626dac57e703bff91ab39194f09e379e5d71c7/Source/Client/Items/AmbientSound.cs#L56-L59

And it seems like we need to set random offset after sound starts playing. To check this, just use flamethrower and listen if flames sound is random

