### PR TITLE
Vectorize float array multiplication

### DIFF
--- a/Source/Client/Extensions/FloatSpanExtensions.cs
+++ b/Source/Client/Extensions/FloatSpanExtensions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+namespace CodeImp.Bloodmasters.Client.Extensions;
+
+public static class FloatSpanExtensions
+{
+    public static unsafe void MultiplyByScalar(this Span<float> span, float value)
+    {
+        if (Vector.IsHardwareAccelerated && span.Length >= Vector<float>.Count)
+        {
+            fixed (float* arrayPtr = &MemoryMarshal.GetReference(span))
+            {
+                float* current = arrayPtr;
+                float* end = arrayPtr + span.Length - span.Length % Vector<float>.Count;
+                do
+                {
+                    Vector<float> result = Vector.Multiply(*(Vector<float>*)current, value);
+                    result.CopyTo(new Span<float>(current, Vector<float>.Count));
+
+                    current += Vector<float>.Count;
+                }
+                while (current < end);
+
+                // Scalar remainder loop
+                for (int i = span.Length - span.Length % Vector<float>.Count; i < span.Length; i++)
+                {
+                    span[i] *= value;
+                }
+            }
+        }
+        // Scalar fallback path
+        else
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] *= value;
+            }
+        }
+    }
+}

--- a/Source/Client/Sound/SampleProviders/LogarithmicVolumeSampleProvider.cs
+++ b/Source/Client/Sound/SampleProviders/LogarithmicVolumeSampleProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using CodeImp.Bloodmasters.Client.Extensions;
 using NAudio.Wave;
 
 namespace CodeImp.Bloodmasters.Client.SampleProviders;
@@ -16,11 +17,16 @@ public class LogarithmicVolumeSampleProvider : ISampleProvider
     public float VolumeHundredthsOfDb
     {
         get => _volumeHundredthsOfDb;
-        set => _volumeHundredthsOfDb = Math.Clamp(value, MinVolumeHundredthsOfDb, MaxVolumeHundredthsOfDb);
+        set
+        {
+            _volumeHundredthsOfDb = Math.Clamp(value, MinVolumeHundredthsOfDb, MaxVolumeHundredthsOfDb);
+            _multiplier = MathF.Pow(10, _volumeHundredthsOfDb / 2000f);
+        }
     }
 
     private readonly ISampleProvider source;
     private float _volumeHundredthsOfDb;
+    private float _multiplier;
 
     public LogarithmicVolumeSampleProvider(ISampleProvider source)
     {
@@ -32,12 +38,7 @@ public class LogarithmicVolumeSampleProvider : ISampleProvider
         int samplesRead = source.Read(buffer, offset, count);
         if (VolumeHundredthsOfDb != 0)
         {
-            var multiplier = MathF.Pow(10, _volumeHundredthsOfDb / 2000f);
-
-            for (int n = 0; n < count; n++)
-            {
-                buffer[offset + n] *= multiplier;
-            }
+            buffer.AsSpan(offset, count).MultiplyByScalar(_multiplier);
         }
         return samplesRead;
     }

--- a/Source/Tests/FloatSpanExtensionsTests.cs
+++ b/Source/Tests/FloatSpanExtensionsTests.cs
@@ -1,0 +1,33 @@
+using CodeImp.Bloodmasters.Client.Extensions;
+
+namespace Bloodmasters.Tests;
+
+public class FloatSpanExtensionsTests
+{
+    [Theory(DisplayName = "Vectorized multiplication of float array should produce same result as scalar multiplication")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(16)]
+    [InlineData(100)]
+    [InlineData(1720)]
+    [InlineData(1123456)]
+    public void VectorizedMultiplicationOfFloatArrayShouldProduceSameResultAsScalarMultiplication(int arraySize)
+    {
+        var array1 = Enumerable.Range(0, arraySize).Select(i => (float)i).ToArray();
+        var array2 = Enumerable.Range(0, arraySize).Select(i => (float)i).ToArray();
+
+        const float scalarValue = 2f;
+
+        array1.AsSpan().MultiplyByScalar(scalarValue);
+
+        for (int i = 0; i < array2.Length; i++)
+        {
+            array2[i] *= scalarValue;
+        }
+
+        Assert.Equal(array1, array2);
+    }
+}


### PR DESCRIPTION
Since volume sound provider is read all the time while playing sounds, it is wise to accelerate it with SIMD.

We might possibly want to do the same for the pan provider in future, but it would require copying Naudio's implementation and changing multiplication to vectorized one

<details>

<summary>Benchmark code</summary>

```c#
BenchmarkRunner.Run<Benchs>();

[MemoryDiagnoser, DisassemblyDiagnoser]
public class Benchs
{
    [Params(1, 10, 16, 1000, 10000)]
    public int ArraySize { get; set; }

    private float[] _buffer;

    [GlobalSetup]
    public void GlobalSetup()
    {
        _buffer = Enumerable.Range(0, ArraySize).Select(i => (float)i).ToArray();
    }

    [Benchmark(Baseline = true)]
    public void ScalarMultiply()
    {
        var buffer = _buffer;

        for (int i = 0; i < buffer.Length; i++)
        {
            buffer[i] *= 2;
        }
    }

    [Benchmark]
    public void VectorizedMultiply()
    {
        var buffer = _buffer;
        buffer.AsSpan().MultiplyByScalar(2);
    }
}
```

</details>

<details>

<summary>Benchmark results</summary>

```

BenchmarkDotNet v0.13.8, Windows 8 (6.2.9200.2215)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100-preview.7.23376.3
  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2


```
| Method             | ArraySize | Mean         | Error      | StdDev     | Ratio | RatioSD | Code Size |
|------------------- |---------- |-------------:|-----------:|-----------:|------:|--------:|----------:|
| **ScalarMultiply**     | **1**         |     **1.406 ns** |  **0.0073 ns** |  **0.0068 ns** |  **1.00** |    **0.00** |      **57 B** |
| VectorizedMultiply | 1         |     1.523 ns |  0.0146 ns |  0.0130 ns |  1.08 |    0.01 |     411 B |
|                    |           |              |            |            |       |         |           |           |             |
| **ScalarMultiply**     | **10**        |     **2.755 ns** |  **0.0333 ns** |  **0.0295 ns** |  **1.00** |    **0.00** |      **57 B** |
| VectorizedMultiply | 10        |     2.430 ns |  0.0690 ns |  0.0709 ns |  0.89 |    0.03 |     411 B |
|                    |           |              |            |            |       |         |           |           |             |
| **ScalarMultiply**     | **16**        |     **4.882 ns** |  **0.0163 ns** |  **0.0144 ns** |  **1.00** |    **0.00** |      **57 B** |
| VectorizedMultiply | 16        |     1.802 ns |  0.0170 ns |  0.0159 ns |  0.37 |    0.00 |     411 B |
|                    |           |              |            |            |       |         |           |           |             |
| **ScalarMultiply**     | **1000**      |   **259.226 ns** |  **0.4911 ns** |  **0.3834 ns** |  **1.00** |    **0.00** |      **57 B** |
| VectorizedMultiply | 1000      |    35.887 ns |  0.4052 ns |  0.3592 ns |  0.14 |    0.00 |     411 B |
|                    |           |              |            |            |       |         |           |           |             |
| **ScalarMultiply**     | **10000**     | **2,576.066 ns** | **15.2295 ns** | **12.7173 ns** |  **1.00** |    **0.00** |      **57 B**|
| VectorizedMultiply | 10000     |   460.545 ns |  3.1623 ns |  2.9580 ns |  0.18 |    0.00 |     411 B |


</details>
