### PR TITLE
Fix client startup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.csproj') }}
 
       - name: Build
-        run: dotnet build Source\Bloodmasters.sln
+        run: dotnet build Source\Bloodmasters.sln --configuration Release
 
       - name: Publish
         run: dotnet publish Source\Bloodmasters.sln --configuration Release --self-contained --runtime win-x64
@@ -50,7 +50,7 @@ jobs:
           path: Publish/Server
 
       - name: Test
-        run: dotnet test Source\Bloodmasters.sln
+        run: dotnet test Source\Bloodmasters.sln --configuration Release
 
   verify:
     name: 'verify'

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -164,7 +164,7 @@ internal sealed class General : SharedGeneral
 
         // Open all archives with archivemanager
         ArchiveManager.Initialize(Paths.BundledResourceDir);
-        ArchiveManager.OpenArchive(Path.Combine(Paths.BundledResourceDir, "sprites"));
+        ArchiveManager.OpenArchive(Path.Combine(Paths.BundledResourceDir, "Sprites"));
 
         // Get the high resolution clock frequency
         timefrequency = TimeProvider.System.TimestampFrequency;

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -56,7 +56,7 @@ internal sealed class General : SharedGeneral
     public static string appname = "";
 
     // Filenames
-    private static string configfilename = "Bloodmasters.cfg";
+    private static string configfilename = Paths.DefaultConfigFileName;
     public static string logfilename = ""; // TODO[#45]: Only used in server code. Remove later.
 
     // Configuration

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -154,6 +154,10 @@ internal sealed class General : SharedGeneral
         // Setup application name
         appname = Assembly.GetExecutingAssembly().GetName().Name;
 
+        // Setup filenames
+        configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
+        logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
+
         // Ensure a Music directory exists
         string musicdir = Path.Combine(Paths.BundledResourceDir, "Music");
         if(!Directory.Exists(musicdir)) Directory.CreateDirectory(musicdir);
@@ -161,10 +165,6 @@ internal sealed class General : SharedGeneral
         // Open all archives with archivemanager
         ArchiveManager.Initialize(Paths.BundledResourceDir);
         ArchiveManager.OpenArchive(Path.Combine(Paths.BundledResourceDir, "sprites"));
-
-        // Setup filenames
-        configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
-        logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
 
         // Get the high resolution clock frequency
         timefrequency = TimeProvider.System.TimestampFrequency;

--- a/Source/Content/Bloodmasters.Content.proj
+++ b/Source/Content/Bloodmasters.Content.proj
@@ -25,20 +25,25 @@
         <ZipContent Include="Textures.zip" Visible="false"/>
         <ZipContent Include="wastedwaters.zip" Visible="false"/>
 
-        <Content Include="Music\*" CopyToPublishDirectory="Always"/>
-        <Content Include="Sprites\*" CopyToPublishDirectory="Always"/>
-        <Content Include="ip-to-country.csv" CopyToPublishDirectory="Always"/>
+        <Content Include="Music\*"/>
+        <Content Include="Sprites\*"/>
+        <Content Include="ip-to-country.csv"/>
     </ItemGroup>
 
-    <Target Name="CompressArchives" BeforeTargets="Publish">
-        <MakeDir Directories="$(ClientPublishDir)" />
+    <Target Name="CreateArchives" BeforeTargets="Publish">
+        <MakeDir Directories="$(ClientPublishDir)"/>
         <ZipDirectory DestinationFile="@(ZipContent->'$(ClientPublishDir)\%(Filename).zip')"
                       SourceDirectory="%(ZipContent.Identity)"
                       Overwrite="true"/>
-        <MakeDir Directories="$(ServerPublishDir)" />
+        <MakeDir Directories="$(ServerPublishDir)"/>
         <ZipDirectory DestinationFile="@(ZipContent->'$(ServerPublishDir)\%(Filename).zip')"
                       SourceDirectory="%(ZipContent.Identity)"
                       Overwrite="true"/>
+    </Target>
+    <Target Name="CopyClientContent" BeforeTargets="Publish">
+        <Copy SourceFiles="@(Content)"
+              DestinationFiles="$(ClientPublishDir)\%(Identity)"
+              SkipUnchangedFiles="true"/>
     </Target>
 
 </Project>

--- a/Source/Launcher/General/General.cs
+++ b/Source/Launcher/General/General.cs
@@ -34,7 +34,7 @@ public class General
 
     // Filenames
     private const string DefaultConfigFileName = "Bloodmasters.cfg";
-    private static string configfilename = DefaultConfigFileName;
+    private static string configfilename = Paths.DefaultConfigFileName;
     private static string ip2countryfilename = "ip-to-country.csv";
     private static string logfilename = "";
 

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -96,6 +96,8 @@ public static class Paths
                     "Config"
                 )).FullName;
 
+    public const string DefaultConfigFileName = "Bloodmasters.cfg";
+
     /// <summary>Directory for the log files. Write access.</summary>
     // TODO[#93]: Logs in production should be moved to another place
     public static readonly string LogDirPath = AppBaseDir;


### PR DESCRIPTION
Closes #130.

The previous issue was caused by a problem in distribution: music and sprites weren't packed.

Also, I've fixed the client startup logging for the client to provide better diagnostics next time.