### PR TITLE
(#98) Allows overriding dev mode in Paths.cs

### DIFF
--- a/Source/Client/General/Arena.cs
+++ b/Source/Client/General/Arena.cs
@@ -490,7 +490,7 @@ public class Arena
         int dynvissecs = 0;
 
         // Open file for writing
-        FileStream outfile = File.Open(Path.Combine(Paths.LogDirPath, "mapinfo.txt"),
+        FileStream outfile = File.Open(Path.Combine(Paths.Instance.LogDirPath, "mapinfo.txt"),
             FileMode.Create, FileAccess.Write, FileShare.Read);
         StreamWriter writer = new StreamWriter(outfile);
 

--- a/Source/Client/General/GConsole.cs
+++ b/Source/Client/General/GConsole.cs
@@ -667,7 +667,7 @@ public class GConsole
     {
         // Make path and filename
         string filename = General.mapname + "_" + DateTime.Now.ToString("MM\\_dd\\_yyyy\\_HH\\_mm\\_ss") + ".png";
-        string pathname = Path.Combine(Paths.ScreenshotsDir);
+        string pathname = Path.Combine(Paths.Instance.ScreenshotsDir);
         string filepathname = Path.Combine(pathname, filename);
 
         // Ensure screenshots directory exists
@@ -909,7 +909,7 @@ public class GConsole
             try
             {
                 // When no path given, write to the log directory
-                Directory.SetCurrentDirectory(Paths.LogDirPath);
+                Directory.SetCurrentDirectory(Paths.Instance.LogDirPath);
 
                 // Open the log file
                 log = File.CreateText(args);

--- a/Source/Client/General/General.cs
+++ b/Source/Client/General/General.cs
@@ -180,16 +180,16 @@ internal sealed class General : SharedGeneral
         appname = Assembly.GetExecutingAssembly().GetName().Name;
 
         // Setup filenames
-        configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
-        logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
+        configfilename = Path.Combine(Paths.Instance.ConfigDirPath, configfilename);
+        logfilename = Path.Combine(Paths.Instance.LogDirPath, appname + ".log");
 
         // Ensure a Music directory exists
-        string musicdir = Path.Combine(Paths.BundledResourceDir, "Music");
+        string musicdir = Path.Combine(Paths.Instance.BundledResourceDir, "Music");
         if(!Directory.Exists(musicdir)) Directory.CreateDirectory(musicdir);
 
         // Open all archives with archivemanager
-        ArchiveManager.Initialize(Paths.BundledResourceDir);
-        ArchiveManager.OpenArchive(Path.Combine(Paths.BundledResourceDir, "Sprites"));
+        ArchiveManager.Initialize(Paths.Instance.BundledResourceDir);
+        ArchiveManager.OpenArchive(Path.Combine(Paths.Instance.BundledResourceDir, "Sprites"));
 
         // Get the high resolution clock frequency
         timefrequency = TimeProvider.System.TimestampFrequency;
@@ -352,8 +352,8 @@ internal sealed class General : SharedGeneral
         ArchiveManager.Dispose();
 
         // Delete the temporary directory
-        if(!string.IsNullOrEmpty(Paths.TempDir))
-            try { Directory.Delete(Paths.TempDir, true); } catch(Exception) { }
+        if(!string.IsNullOrEmpty(Paths.Instance.TempDir))
+            try { Directory.Delete(Paths.Instance.TempDir, true); } catch(Exception) { }
 
         // End of program
         Application.Exit();
@@ -404,7 +404,7 @@ internal sealed class General : SharedGeneral
         if(!File.Exists(allargs))
         {
             // Try in local path
-            if(!File.Exists(Path.Combine(Paths.ConfigDirPath, allargs)))
+            if(!File.Exists(Path.Combine(Paths.Instance.ConfigDirPath, allargs)))
             {
                 // Cannot find configuration
                 MessageBox.Show("Unable to load the configuration file " + Path.GetFileName(allargs) + ".", Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -413,7 +413,7 @@ internal sealed class General : SharedGeneral
             else
             {
                 // Its in the local path
-                allargs = Path.Combine(Paths.ConfigDirPath, allargs);
+                allargs = Path.Combine(Paths.Instance.ConfigDirPath, allargs);
             }
         }
 
@@ -1999,7 +1999,7 @@ internal sealed class General : SharedGeneral
         clients[localclientid] = General.localclient;
 
         // Load the map
-        try { map = new ClientMap(mapname, false, Paths.TempDir); }
+        try { map = new ClientMap(mapname, false, Paths.Instance.TempDir); }
         catch(FileNotFoundException) { return "You do not have the map \"" + mapname + "\"."; }
 
         // Load the arena
@@ -2216,7 +2216,7 @@ internal sealed class General : SharedGeneral
         {
             // No proper commands given
             // Run the standard launcher
-            Process.Start(Paths.LauncherExecutablePath);
+            Process.Start(Paths.Instance.LauncherExecutablePath);
             return;
         }
 
@@ -2266,7 +2266,7 @@ internal sealed class General : SharedGeneral
                                 serverrunning = true;
 
                                 // Correct path if needed
-                                if (!File.Exists(hostfile)) hostfile = Path.Combine(Paths.ConfigDirPath, hostfile);
+                                if (!File.Exists(hostfile)) hostfile = Path.Combine(Paths.Instance.ConfigDirPath, hostfile);
 
                                 // Load server configuration
                                 Configuration scfg = new Configuration(true);
@@ -2288,7 +2288,7 @@ internal sealed class General : SharedGeneral
                                 serverrunning = true;
 
                                 // Correct path if needed
-                                if (!File.Exists(dedfile)) hostfile = Path.Combine(Paths.ConfigDirPath, dedfile);
+                                if (!File.Exists(dedfile)) hostfile = Path.Combine(Paths.Instance.ConfigDirPath, dedfile);
 
                                 // Load server configuration
                                 Configuration scfg = new Configuration(true);

--- a/Source/Client/Graphics/Direct3D.cs
+++ b/Source/Client/Graphics/Direct3D.cs
@@ -1450,7 +1450,7 @@ internal sealed class Direct3D
         if(mipmap) mipmaplevels = 2;
 
         // Check if the file exists
-        if(File.Exists(Path.Combine(Paths.BundledResourceDir, filename)))
+        if(File.Exists(Path.Combine(Paths.Instance.BundledResourceDir, filename)))
         {
             // Check if already loaded
             if((textures.TryGetValue(filename, out TextureResource textureResource)) && (usecache == true))
@@ -1461,7 +1461,7 @@ internal sealed class Direct3D
             else
             {
                 // Load texture file
-                t =  Texture.FromFile(d3dd, Path.Combine(Paths.BundledResourceDir, filename), width, height, mipmaplevels, Usage.None, Format.Unknown,
+                t =  Texture.FromFile(d3dd, Path.Combine(Paths.Instance.BundledResourceDir, filename), width, height, mipmaplevels, Usage.None, Format.Unknown,
                     Pool.Default, Filter.Linear | Filter.MirrorU | Filter.MirrorV | Filter.Dither,
                     Filter.Triangle, 0, out i);
 

--- a/Source/Client/Sound/Jukebox.cs
+++ b/Source/Client/Sound/Jukebox.cs
@@ -43,7 +43,7 @@ public class Jukebox
     private static string[] GetPlaylistFiles()
     {
         // Make playlist from directory
-        string musicdir = Path.Combine(Paths.BundledResourceDir, "Music");
+        string musicdir = Path.Combine(Paths.Instance.BundledResourceDir, "Music");
 
         var playlistFiles = Directory.GetFiles(musicdir, "*.mp3");
 

--- a/Source/DedicatedServer/General.cs
+++ b/Source/DedicatedServer/General.cs
@@ -52,10 +52,10 @@ internal sealed class General : SharedGeneral
         appname = Assembly.GetExecutingAssembly().GetName().Name;
 
         // Open all archives with archivemanager
-        ArchiveManager.Initialize(Paths.BundledResourceDir);
+        ArchiveManager.Initialize(Paths.Instance.BundledResourceDir);
 
         // Setup filenames
-        logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
+        logfilename = Path.Combine(Paths.Instance.LogDirPath, appname + ".log");
 
         // Setup clock
         SharedGeneral.previoustime = SharedGeneral.GetCurrentTime();
@@ -80,7 +80,7 @@ internal sealed class General : SharedGeneral
         ArchiveManager.Dispose();
 
         // Delete the temporary directory
-        if(!string.IsNullOrEmpty(Paths.TempDir)) Directory.Delete(Paths.TempDir, true);
+        if(!string.IsNullOrEmpty(Paths.Instance.TempDir)) Directory.Delete(Paths.Instance.TempDir, true);
 
         // End of program
         //Application.Exit();
@@ -94,7 +94,7 @@ internal sealed class General : SharedGeneral
     public static string LoadServerConfiguration(string[] args)
     {
         // Determine config file
-        string configfile = Path.Combine(Paths.ConfigDirPath, "bmserver.cfg");
+        string configfile = Path.Combine(Paths.Instance.ConfigDirPath, "bmserver.cfg");
         if(args.Length > 0) configfile = args[args.Length - 1];
 
         // Load the config file
@@ -116,7 +116,7 @@ internal sealed class General : SharedGeneral
             else
             {
                 // Make path relative to app path
-                logfilename = Path.Combine(Paths.LogDirPath, logfile);
+                logfilename = Path.Combine(Paths.Instance.LogDirPath, logfile);
             }
         }
 

--- a/Source/Launcher/General/General.cs
+++ b/Source/Launcher/General/General.cs
@@ -71,9 +71,9 @@ public class General
         appname = Assembly.GetExecutingAssembly().GetName().Name;
 
         // Setup filenames
-        configfilename = Path.Combine(Paths.ConfigDirPath, configfilename);
-        logfilename = Path.Combine(Paths.LogDirPath, appname + ".log");
-        ip2countryfilename = Path.Combine(Paths.BundledResourceDir, ip2countryfilename);
+        configfilename = Path.Combine(Paths.Instance.ConfigDirPath, configfilename);
+        logfilename = Path.Combine(Paths.Instance.LogDirPath, appname + ".log");
+        ip2countryfilename = Path.Combine(Paths.Instance.BundledResourceDir, ip2countryfilename);
 
         DeployTemplateConfig();
 
@@ -93,7 +93,7 @@ public class General
     private static void DeployTemplateConfig()
     {
         if (File.Exists(configfilename)) return;
-        var templateConfig = Path.Combine(Paths.BundledResourceDir, DefaultConfigFileName);
+        var templateConfig = Path.Combine(Paths.Instance.BundledResourceDir, DefaultConfigFileName);
         if (!File.Exists(templateConfig)) return;
         var configDirectory = Path.GetDirectoryName(configfilename);
         if (configDirectory != null)
@@ -168,7 +168,7 @@ public class General
 
                     // Open all archives with archivemanager
                     mainwindow.ShowStatus("Loading data archives...");
-                    ArchiveManager.Initialize(Paths.BundledResourceDir);
+                    ArchiveManager.Initialize(Paths.Instance.BundledResourceDir);
 
                     // Refrehs maps in list
                     mainwindow.RefreshMapsLists();
@@ -269,8 +269,8 @@ public class General
         ArchiveManager.Dispose();
 
         // Delete the temporary directory
-        if(!string.IsNullOrEmpty(Paths.TempDir))
-            try { Directory.Delete(Paths.TempDir, true); } catch(Exception) { }
+        if(!string.IsNullOrEmpty(Paths.Instance.TempDir))
+            try { Directory.Delete(Paths.Instance.TempDir, true); } catch(Exception) { }
 
         // End of program
         Application.Exit();
@@ -407,7 +407,7 @@ public class General
         mainwindow.ShowStatus("Launching game...");
 
         // Determine launch filename
-        string launchfile = MakeUniqueFilename(Paths.ConfigDirPath, "launch_", ".cfg");
+        string launchfile = MakeUniqueFilename(Paths.Instance.ConfigDirPath, "launch_", ".cfg");
         serverfile = servfile;
 
         // Write launch file
@@ -415,8 +415,8 @@ public class General
 
         // Make the process
         bmproc = new Process();
-        bmproc.StartInfo.FileName = Paths.ClientExecutablePath;
-        bmproc.StartInfo.WorkingDirectory = Path.GetDirectoryName(Paths.ClientExecutablePath);
+        bmproc.StartInfo.FileName = Paths.Instance.ClientExecutablePath;
+        bmproc.StartInfo.WorkingDirectory = Path.GetDirectoryName(Paths.Instance.ClientExecutablePath);
         bmproc.StartInfo.Arguments = launchfile;
         bmproc.StartInfo.CreateNoWindow = false;
         bmproc.StartInfo.ErrorDialog = false;

--- a/Source/Launcher/Interface/FormDownload.cs
+++ b/Source/Launcher/Interface/FormDownload.cs
@@ -300,7 +300,7 @@ public class FormDownload : System.Windows.Forms.Form
         if(contentlength > 0) prgStatus.Maximum = contentlength;
 
         // Make the file
-        filename = Path.Combine(Paths.DownloadedResourceDir, server.MapName + ".zip");
+        filename = Path.Combine(Paths.Instance.DownloadedResourceDir, server.MapName + ".zip");
         file = File.Open(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
 
         // Get the http download

--- a/Source/Launcher/Interface/FormMain.cs
+++ b/Source/Launcher/Interface/FormMain.cs
@@ -1803,7 +1803,7 @@ public class FormMain : System.Windows.Forms.Form
                         download.Dispose();
 
                         // Check if new file exists
-                        filename = Path.Combine(Paths.DownloadedResourceDir, gitem.MapName + ".zip");
+                        filename = Path.Combine(Paths.Instance.DownloadedResourceDir, gitem.MapName + ".zip");
                         if (File.Exists(filename))
                         {
                             // Busy!

--- a/Source/Launcher/Interface/FormMain.cs
+++ b/Source/Launcher/Interface/FormMain.cs
@@ -1292,7 +1292,7 @@ public class FormMain : System.Windows.Forms.Form
                 string mname = wfparts[1].Substring(0, wfparts[1].Length - 4);
 
                 // Load the map information
-                Map wadmap = new LauncherMap(mname, true, Paths.TempDir);
+                Map wadmap = new LauncherMap(mname, true, Paths.Instance.TempDir);
 
                 // Check if game type is supported
                 if (((cmbServerType.SelectedIndex == 0) && wadmap.SupportsDM) ||
@@ -1520,7 +1520,7 @@ public class FormMain : System.Windows.Forms.Form
         General.SaveConfiguration();
 
         // Make the server configuration file
-        string scfgfile = General.MakeUniqueFilename(Paths.ConfigDirPath, "server_", ".cfg");
+        string scfgfile = General.MakeUniqueFilename(Paths.Instance.ConfigDirPath, "server_", ".cfg");
         Configuration scfg = MakeServerConfig(true);
         scfg.SaveConfiguration(scfgfile);
 
@@ -1662,7 +1662,7 @@ public class FormMain : System.Windows.Forms.Form
             try
             {
                 // Load the map information
-                Map wadmap = new LauncherMap(lstMaps.SelectedItem.ToString(), true, Paths.TempDir);
+                Map wadmap = new LauncherMap(lstMaps.SelectedItem.ToString(), true, Paths.Instance.TempDir);
 
                 // Display map information
                 lblMapTitle.Text = wadmap.Title;
@@ -1803,7 +1803,7 @@ public class FormMain : System.Windows.Forms.Form
                         download.Dispose();
 
                         // Check if new file exists
-                        filename = Path.Combine(Paths.DownloadedResourceDir, gitem.MapName + ".zip");
+                        filename = Path.Combine(Paths.Instance.DownloadedResourceDir, gitem.MapName + ".zip");
                         if (File.Exists(filename))
                         {
                             // Busy!

--- a/Source/Server/General/GameServer.cs
+++ b/Source/Server/General/GameServer.cs
@@ -588,7 +588,7 @@ public sealed class GameServer
         Write("Server is loading map \"" + nextmapname + "\"...", true);
 
         // Load the map title
-        Map mapcfg = new ServerMap(nextmapname, true, Paths.TempDir);
+        Map mapcfg = new ServerMap(nextmapname, true, Paths.Instance.TempDir);
         string maptitle = mapcfg.Title;
         mapcfg.Dispose();
 
@@ -612,7 +612,7 @@ public sealed class GameServer
         LoadLocalBans();
 
         // Load the map
-        map = new ServerMap(nextmapname, false, Paths.TempDir);
+        map = new ServerMap(nextmapname, false, Paths.Instance.TempDir);
 
         // New items
         items = new Dictionary<string, Item>();

--- a/Source/Shared/ArchiveManager.cs
+++ b/Source/Shared/ArchiveManager.cs
@@ -15,7 +15,7 @@ public class ArchiveManager
     private static readonly Dictionary<string, Archive> archives = new();
 
     // Temporary path
-    private static readonly string tempPath = Paths.TempDir;
+    private static readonly string tempPath = Paths.Instance.TempDir;
 
     #endregion
 

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -24,13 +24,7 @@ public abstract class Paths
 
     private static string EvaluateAppBaseDir()
     {
-        var modulePath = Assembly.GetEntryAssembly()?.Location ?? Process.GetCurrentProcess().MainModule?.FileName;
-
-        if (modulePath is null)
-        {
-            return Environment.CurrentDirectory;
-        }
-
+        var modulePath = Assembly.GetCallingAssembly().Location;
         return Path.GetDirectoryName(modulePath) ?? Environment.CurrentDirectory;
     }
 

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -11,6 +11,7 @@ internal enum StartupMode
 
 public abstract class Paths
 {
+    public const string GameName = "Bloodmasters";
     public const string DefaultConfigFileName = "Bloodmasters.cfg";
 
     protected const string ClientExecutableFileName = "Bloodmasters.exe";
@@ -18,6 +19,9 @@ public abstract class Paths
 
     private static readonly Lazy<Paths> _instance
         = new(() => Create(StartupMode.Usual));
+
+    public static readonly Paths Instance
+        = _instance.Value;
 
     internal static Paths Create(StartupMode startupMode)
         => startupMode switch
@@ -35,7 +39,7 @@ public abstract class Paths
     {
         var modulePath = Assembly.GetEntryAssembly()?.Location ?? Process.GetCurrentProcess().MainModule?.FileName;
 
-        if (modulePath == null)
+        if (modulePath is null)
         {
             return Environment.CurrentDirectory;
         }
@@ -52,9 +56,6 @@ public abstract class Paths
 
         return Directory.CreateDirectory(targetPath).FullName;
     }
-
-    public static Paths Instance
-        => _instance.Value;
 
     public abstract string ClientExecutablePath { get; }
 
@@ -76,18 +77,18 @@ public abstract class Paths
     public string ScreenshotsDir { get; } =
         EvaluateDir(
             Environment.SpecialFolder.MyPictures,
-            "Bloodmasters");
+            GameName);
 
     /// <summary>Directory for the downloaded resources. Read + write access.</summary>
     public string DownloadedResourceDir { get; } =
         EvaluateDir(
             Environment.SpecialFolder.LocalApplicationData,
-            "Bloodmasters",
+            GameName,
             "Downloads");
 
     /// <summary>Directory for temporary data. Read + write access.</summary>
     public string TempDir { get; } =
-        Directory.CreateTempSubdirectory(prefix: "Bloodmasters").FullName;
+        Directory.CreateTempSubdirectory(GameName).FullName;
 }
 
 file sealed class UsualPaths : Paths
@@ -108,7 +109,7 @@ file sealed class UsualPaths : Paths
     public override string ConfigDirPath { get; } =
         EvaluateDir(
             Environment.SpecialFolder.ApplicationData,
-            "Bloodmasters",
+            GameName,
             "Config");
 }
 

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -5,7 +5,7 @@ namespace CodeImp.Bloodmasters;
 
 internal enum StartupMode
 {
-    Usual,
+    Production,
     Dev
 }
 
@@ -18,7 +18,7 @@ public abstract class Paths
     protected const string LauncherExecutableFileName = "BMLauncher.exe";
 
     private static readonly Lazy<Paths> _instance
-        = new(() => Create(StartupMode.Usual));
+        = new(() => Create(StartupMode.Production));
 
     public static readonly Paths Instance
         = _instance.Value;
@@ -26,7 +26,7 @@ public abstract class Paths
     internal static Paths Create(StartupMode startupMode)
         => startupMode switch
         {
-            StartupMode.Usual => new UsualPaths(),
+            StartupMode.Production => new ProductionPaths(),
             StartupMode.Dev => new DevPaths(),
             _ => throw new NotSupportedException()
         };
@@ -91,7 +91,7 @@ public abstract class Paths
         Directory.CreateTempSubdirectory(GameName).FullName;
 }
 
-file sealed class UsualPaths : Paths
+file sealed class ProductionPaths : Paths
 {
     /// <inheritdoc />
     public override string ClientExecutablePath

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -59,6 +59,8 @@ public abstract class Paths
         return Directory.CreateDirectory(targetPath).FullName;
     }
 
+    internal abstract StartupMode CurrentMode { get; }
+
     public abstract string ClientExecutablePath { get; }
 
     public abstract string ContentDirPath { get; }
@@ -96,6 +98,10 @@ public abstract class Paths
 
 file sealed class ProductionPaths : Paths
 {
+    /// <inheritdoc />
+    internal override StartupMode CurrentMode
+        => StartupMode.Production;
+
     /// <inheritdoc />
     public override string ClientExecutablePath
         => Path.Combine(AppBaseDir, ClientExecutableFileName);
@@ -157,6 +163,10 @@ file sealed class DevPaths : Paths
             FindSolutionRootRelativelyTo(AppBaseDir)
                 ?? throw new InvalidOperationException("Unable to find solution root");
     }
+
+    /// <inheritdoc />
+    internal override StartupMode CurrentMode
+        => StartupMode.Dev;
 
     /// <inheritdoc />
     public override string ClientExecutablePath

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -131,10 +131,6 @@ file sealed class DevPaths : Paths
     public static readonly bool HasDevModeMarker =
         File.Exists(Path.Combine(AppBaseDir, DevModeMarkerFileName));
 
-    private static readonly string SolutionRootPath =
-        FindSolutionRootRelativelyTo(AppBaseDir)
-            ?? throw new InvalidOperationException("Unable to find solution root");
-
     private static string? FindSolutionRootRelativelyTo(string appBaseDir)
     {
         var currentDir = appBaseDir;
@@ -147,6 +143,8 @@ file sealed class DevPaths : Paths
         return currentDir;
     }
 
+    private readonly string _solutionRootPath;
+
     public DevPaths()
     {
         if (!HasDevModeMarker)
@@ -154,12 +152,16 @@ file sealed class DevPaths : Paths
             throw new InvalidOperationException(
                 $"{nameof(DevPaths)} can only be used if the file \"{DevModeMarkerFileName}\" exists");
         }
+
+        _solutionRootPath =
+            FindSolutionRootRelativelyTo(AppBaseDir)
+                ?? throw new InvalidOperationException("Unable to find solution root");
     }
 
     /// <inheritdoc />
     public override string ClientExecutablePath
         => Path.Combine(
-            SolutionRootPath,
+            _solutionRootPath,
             "Source",
             "Client",
             "bin",
@@ -169,12 +171,12 @@ file sealed class DevPaths : Paths
 
     /// <inheritdoc />
     public override string ContentDirPath
-        => Path.Combine(SolutionRootPath, "Source", "Content");
+        => Path.Combine(_solutionRootPath, "Source", "Content");
 
     /// <inheritdoc />
     public override string LauncherExecutablePath
         => Path.Combine(
-            SolutionRootPath,
+            _solutionRootPath,
             "Source",
             "Launcher",
             "bin",
@@ -184,5 +186,5 @@ file sealed class DevPaths : Paths
 
     /// <inheritdoc />
     public override string ConfigDirPath
-        => Path.Combine(SolutionRootPath, "Source", "Config", "Debug");
+        => Path.Combine(_solutionRootPath, "Source", "Config", "Debug");
 }

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -37,8 +37,8 @@ public abstract class Paths
     internal static Paths Create(StartupMode startupMode)
         => startupMode switch
         {
-            StartupMode.AutoDetect when DevPaths.HasDevModeMarker => new DevPaths(),
-            StartupMode.AutoDetect or StartupMode.Production => new ProductionPaths(),
+            StartupMode.AutoDetect => DevPaths.HasDevModeMarker ? new DevPaths() : new ProductionPaths(),
+            StartupMode.Production => new ProductionPaths(),
             StartupMode.Dev => new DevPaths(),
             _ => throw new NotSupportedException()
         };

--- a/Source/Shared/Paths.cs
+++ b/Source/Shared/Paths.cs
@@ -71,7 +71,8 @@ public abstract class Paths
 
     /// <summary>Directory for the log files. Write access.</summary>
     // TODO[#93]: Logs in production should be moved to another place
-    public string LogDirPath { get; } = AppBaseDir;
+    public string LogDirPath
+        => AppBaseDir;
 
     /// <summary>Directory for screenshots. Write access.</summary>
     public string ScreenshotsDir { get; } =

--- a/Source/Tests/Paths/ConfigDirPathTests.cs
+++ b/Source/Tests/Paths/ConfigDirPathTests.cs
@@ -6,15 +6,14 @@ public class ConfigDirPathTests
     public void ConfigDirPathShouldBeNamedConfigInProductionMode()
     {
         // Arrange
-        var sut = CodeImp.Bloodmasters.Paths.Instance;
+        var sut = CodeImp.Bloodmasters.Paths.Create(StartupMode.Production);
         var dirName = Path.GetFileName(sut.ConfigDirPath);
 
         // Assert
         Assert.Equal("Config", dirName);
     }
 
-    [Fact(DisplayName = "ConfigDirPath should be named 'Debug' in dev mode",
-        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    [Fact(DisplayName = "ConfigDirPath should be named 'Debug' in dev mode")]
     public void ConfigDirPathShouldBeNamedDebugInDevMode()
     {
         // Arrange
@@ -25,16 +24,24 @@ public class ConfigDirPathTests
         Assert.Equal("Debug", dirName);
     }
 
-    [Fact(DisplayName = "ConfigDirPath should be subdirectory of the 'Bloodmasters' directory in dev mode",
-        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    [Fact(DisplayName = "ConfigDirPath should be subdirectory of the 'Bloodmasters' directory in production mode")]
+    public void ConfigDirPathShouldBeSubdirectoryOfBloodmastersInProductionMode()
+    {
+        // Arrange
+        var sut = CodeImp.Bloodmasters.Paths.Create(StartupMode.Production);
+        var bloodmastersDirPath = Path.GetDirectoryName(sut.ConfigDirPath);
+
+        // Assert
+        Assert.Equal("Bloodmasters", Path.GetFileName(bloodmastersDirPath));
+    }
+
+    [Fact(DisplayName = "ConfigDirPath should be subdirectory of the 'Bloodmasters' directory in dev mode")]
     public void ConfigDirPathShouldBeSubdirectoryOfBloodmastersInDevMode()
     {
         // Arrange
         var sut = CodeImp.Bloodmasters.Paths.Create(StartupMode.Dev);
-        var dirPath = sut.ConfigDirPath;
-        var bloodmastersDirPath = Path.GetDirectoryName(dirPath);
 
         // Assert
-        Assert.Equal("Bloodmasters", Path.GetFileName(bloodmastersDirPath));
+        Assert.Contains("bloodmasters", sut.ConfigDirPath.Split(Path.DirectorySeparatorChar));
     }
 }

--- a/Source/Tests/Paths/ConfigDirPathTests.cs
+++ b/Source/Tests/Paths/ConfigDirPathTests.cs
@@ -2,8 +2,8 @@ namespace CodeImp.Bloodmasters.Tests.Paths;
 
 public class ConfigDirPathTests
 {
-    [Fact(DisplayName = "ConfigDirPath should be named 'Config' in usual mode")]
-    public void ConfigDirPathShouldBeNamedConfigInUsualMode()
+    [Fact(DisplayName = "ConfigDirPath should be named 'Config' in production mode")]
+    public void ConfigDirPathShouldBeNamedConfigInProductionMode()
     {
         // Arrange
         var sut = CodeImp.Bloodmasters.Paths.Instance;

--- a/Source/Tests/Paths/ConfigDirPathTests.cs
+++ b/Source/Tests/Paths/ConfigDirPathTests.cs
@@ -2,25 +2,36 @@ namespace CodeImp.Bloodmasters.Tests.Paths;
 
 public class ConfigDirPathTests
 {
-    [Fact(DisplayName = "ConfigDirPath should be named 'Debug' in dev mode and 'Config' otherwise")]
-    public void ConfigDirPathShouldBeNamedDebugInDevModeAndConfigOtherwise()
+    [Fact(DisplayName = "ConfigDirPath should be named 'Config' in usual mode")]
+    public void ConfigDirPathShouldBeNamedConfigInUsualMode()
     {
         // Arrange
-        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.ConfigDirPath);
+        var sut = CodeImp.Bloodmasters.Paths.Instance;
+        var dirName = Path.GetFileName(sut.ConfigDirPath);
 
         // Assert
-        Assert.Equal(
-            CodeImp.Bloodmasters.Paths.IsDevModeBuild ? "Debug" : "Config",
-            dirName);
+        Assert.Equal("Config", dirName);
     }
 
-    [Fact(DisplayName = "ConfigDirPath should be subdirectory of the 'Bloodmasters' directory in dev mode")]
-    public void DownloadedResourceDirShouldBeSubdirectoryOfBloodmasters()
+    [Fact(DisplayName = "ConfigDirPath should be named 'Debug' in dev mode",
+        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    public void ConfigDirPathShouldBeNamedDebugInDevMode()
     {
-        if (CodeImp.Bloodmasters.Paths.IsDevModeBuild) return;
-
         // Arrange
-        var dirPath = CodeImp.Bloodmasters.Paths.ConfigDirPath;
+        var sut = CodeImp.Bloodmasters.Paths.Create(StartupMode.Dev);
+        var dirName = Path.GetFileName(sut.ConfigDirPath);
+
+        // Assert
+        Assert.Equal("Debug", dirName);
+    }
+
+    [Fact(DisplayName = "ConfigDirPath should be subdirectory of the 'Bloodmasters' directory in dev mode",
+        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    public void ConfigDirPathShouldBeSubdirectoryOfBloodmastersInDevMode()
+    {
+        // Arrange
+        var sut = CodeImp.Bloodmasters.Paths.Create(StartupMode.Dev);
+        var dirPath = sut.ConfigDirPath;
         var bloodmastersDirPath = Path.GetDirectoryName(dirPath);
 
         // Assert

--- a/Source/Tests/Paths/DownloadedResourceDirTests.cs
+++ b/Source/Tests/Paths/DownloadedResourceDirTests.cs
@@ -6,7 +6,7 @@ public class DownloadedResourceDirTests
     public void DownloadedResourceDirShouldBeNamedBloodmasters()
     {
         // Arrange
-        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.DownloadedResourceDir);
+        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.Instance.DownloadedResourceDir);
 
         // Assert
         Assert.Equal("Downloads", dirName);
@@ -16,7 +16,7 @@ public class DownloadedResourceDirTests
     public void DownloadedResourceDirShouldBeSubdirectoryOfBloodmasters()
     {
         // Arrange
-        var dirPath = CodeImp.Bloodmasters.Paths.DownloadedResourceDir;
+        var dirPath = CodeImp.Bloodmasters.Paths.Instance.DownloadedResourceDir;
         var bloodmastersDirPath = Path.GetDirectoryName(dirPath);
 
         // Assert

--- a/Source/Tests/Paths/GeneralTests.cs
+++ b/Source/Tests/Paths/GeneralTests.cs
@@ -18,9 +18,9 @@ public class GeneralTests
 
     public static IEnumerable<object[]> GetAllDirPaths()
     {
-        yield return new object[] { CodeImp.Bloodmasters.Paths.TempDir };
-        yield return new object[] { CodeImp.Bloodmasters.Paths.DownloadedResourceDir };
-        yield return new object[] { CodeImp.Bloodmasters.Paths.ConfigDirPath };
-        yield return new object[] { CodeImp.Bloodmasters.Paths.ScreenshotsDir };
+        yield return new object[] { CodeImp.Bloodmasters.Paths.Instance.TempDir };
+        yield return new object[] { CodeImp.Bloodmasters.Paths.Instance.DownloadedResourceDir };
+        yield return new object[] { CodeImp.Bloodmasters.Paths.Instance.ConfigDirPath };
+        yield return new object[] { CodeImp.Bloodmasters.Paths.Instance.ScreenshotsDir };
     }
 }

--- a/Source/Tests/Paths/ScreenshotsDirTests.cs
+++ b/Source/Tests/Paths/ScreenshotsDirTests.cs
@@ -6,7 +6,7 @@ public class ScreenshotsDirTests
     public void ScreenshotsDirShouldBeNamedBloodmasters()
     {
         // Arrange
-        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.ScreenshotsDir);
+        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.Instance.ScreenshotsDir);
 
         // Assert
         Assert.Equal("Bloodmasters", dirName);

--- a/Source/Tests/Paths/StartupModeTests.cs
+++ b/Source/Tests/Paths/StartupModeTests.cs
@@ -12,8 +12,7 @@ public sealed class StartupModeTests
         Assert.Equal(StartupMode.Production, sut.CurrentMode);
     }
 
-    [Fact(DisplayName = "StartupMode should be Dev when paths created",
-        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    [Fact(DisplayName = "StartupMode should be Dev when paths created")]
     public void ShouldCreateProductionPathsWhenProductionModePassed()
     {
         // Arrange

--- a/Source/Tests/Paths/StartupModeTests.cs
+++ b/Source/Tests/Paths/StartupModeTests.cs
@@ -1,0 +1,25 @@
+namespace CodeImp.Bloodmasters.Tests.Paths;
+
+public sealed class StartupModeTests
+{
+    [Fact(DisplayName = "StartupMode should be Production when paths created")]
+    public void StartupModeShouldBeProductionWhenPathsCreated()
+    {
+        // Arrange
+        var sut = Bloodmasters.Paths.Create(StartupMode.Production);
+
+        // Assert
+        Assert.Equal(StartupMode.Production, sut.CurrentMode);
+    }
+
+    [Fact(DisplayName = "StartupMode should be Dev when paths created",
+        Skip = "Dev mode requires .bloodmasters.dev.marker file")]
+    public void ShouldCreateProductionPathsWhenProductionModePassed()
+    {
+        // Arrange
+        var sut = Bloodmasters.Paths.Create(StartupMode.Dev);
+
+        // Assert
+        Assert.Equal(StartupMode.Dev, sut.CurrentMode);
+    }
+}

--- a/Source/Tests/Paths/TempDirPathTests.cs
+++ b/Source/Tests/Paths/TempDirPathTests.cs
@@ -6,7 +6,7 @@ public sealed class TempDirPathTests
     public void TemporaryDirectoryShouldContainSuffixBloodmasters()
     {
         // Arrange
-        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.TempDir);
+        var dirName = Path.GetFileName(CodeImp.Bloodmasters.Paths.Instance.TempDir);
 
         // Assert
         Assert.StartsWith("Bloodmasters", dirName);


### PR DESCRIPTION
**Changes:**
- Simplifies the `Paths` code by encapsulating the calculation logic of Dev and Production paths into own classes.
- Allows overriding dev mode for tests
- Migrates the production code to `Paths.Instance` (`Paths.Instance` is thread-safe) [**11.10 upd**: Added automatic `StartupMode` detection by existence of `.bloodmasters.dev.marker` file]

~~**Unresolved:**
Dev mode requires `.bloodmasters.dev.marker` file. Without this file some tests do not work. I haven't figured out how to get around this problem nicely yet~~